### PR TITLE
feat(permissions): add granular permissions for sale order billing an…

### DIFF
--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -1092,8 +1092,10 @@ class SaleController extends Controller
                 'created_by' => $record->created_by_name,
                 'updated_by' => $record->updated_by_name,
                 'can_edit' => in_array($req->transfer_type, [Sale::TRANSFER_TYPE_NORMAL, Sale::TRANSFER_TYPE_TRANSFER_FROM]) && hasPermission('sale.sale_order.edit'),
-                'can_edit_payment' => (in_array($req->transfer_type, [Sale::TRANSFER_TYPE_NORMAL, Sale::TRANSFER_TYPE_TRANSFER_FROM]) && (isSuperAdmin() || isFinance()))
-                    || ($record->status == Sale::STATUS_CANCELLED && $record->cancellation_charge != null && (isSuperAdmin() || isFinance())),
+                'can_edit_payment' => hasPermission('sale.sale_order.billing') && (
+                    in_array($req->transfer_type, [Sale::TRANSFER_TYPE_NORMAL, Sale::TRANSFER_TYPE_TRANSFER_FROM])
+                    || ($record->status == Sale::STATUS_CANCELLED && $record->cancellation_charge != null)
+                ),
                 'can_view' => hasPermission('sale.sale_order.view_record'),
                 'can_cancel' => in_array($req->transfer_type, [Sale::TRANSFER_TYPE_NORMAL, Sale::TRANSFER_TYPE_TRANSFER_FROM]) && hasPermission('sale.sale_order.cancel') && $record->status == Sale::STATUS_ACTIVE,
                 'can_delete' => false, // SO no need delete btn
@@ -1214,7 +1216,7 @@ class SaleController extends Controller
         return view('sale_order.form', [
             'sale' => $sale,
             'convert_from_quo' => $sale->convertFromQuo(),
-            'can_edit_payment' => isSuperAdmin() || isFinance(),
+            'can_edit_payment' => hasPermission('sale.sale_order.billing'),
             'is_view' => $is_view,
             'has_pending_approval' => $has_pending_approval,
             'customers' => $customers,

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -734,7 +734,7 @@ class ViewServiceProvider extends ServiceProvider
             $credit_term_payment_method_ids = getPaymentMethodCreditTermIds();
 
             $view->with([
-                'can_payment_amount' => in_array(Role::SUPERADMIN, getUserRoleId(Auth::user())) || in_array(Role::FINANCE, getUserRoleId(Auth::user())),
+                'can_payment_amount' => hasPermission('sale.sale_order.billing'),
                 'payment_statuses' => $payment_statuses,
                 'payment_methods' => $payment_methods,
                 'credit_payment_method_ids' => $credit_term_payment_method_ids,

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -100,6 +100,7 @@ return [
     'sale.sale_order.delete' => 'Show the Delete button on pending and e-order sale order rows',
     'sale.sale_order.convert_from' => 'Show the Convert From Quotation button on the sale order listing page to generate a sale order from approved quotations',
     'sale.sale_order.convert_to' => 'Show the Convert to Delivery Order button on the sale order listing page',
+    'sale.sale_order.billing' => 'Show the Payment button on sale order rows and access the payment form to manage payment records',
 
     // Sales - Cash Sale
     'sale.cash_sale.view' => 'Show the Cash Sale menu under Sale & Invoice and access the walk-in cash sale listing page',
@@ -163,6 +164,8 @@ return [
     'production_request.complete' => 'Show the Complete and Cancel buttons on each production request row to mark it as completed or submit cancellation',
     'production.cancel' => 'Show the Cancel Production button on the in-progress production view page',
     'production.complete' => 'Show the Complete Task button on the in-progress production view page',
+    'production.force_complete' => 'Show the Force Complete Task button on the in-progress production view page to request approval for early completion',
+    'production.check_in_milestone' => 'Allow checking in milestones on the in-progress production view page to record milestone progress',
 
     // Ticket
     'ticket.view' => 'Show the Ticket menu under Tasks and access the customer support ticket listing page',

--- a/database/migrations/2026_04_06_000000_add_sale_order_billing_permission.php
+++ b/database/migrations/2026_04_06_000000_add_sale_order_billing_permission.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('permissions')->insert([
+            'name' => 'sale.sale_order.billing',
+            'guard_name' => 'web',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $permissionId = DB::table('permissions')->where('name', 'sale.sale_order.billing')->value('id');
+
+        // Assign to Super Admin and Finance roles (previously hardcoded)
+        foreach ([1, 9] as $roleId) {
+            $exists = DB::table('role_has_permissions')
+                ->where('permission_id', $permissionId)
+                ->where('role_id', $roleId)
+                ->exists();
+
+            if (! $exists) {
+                DB::table('role_has_permissions')->insert([
+                    'permission_id' => $permissionId,
+                    'role_id' => $roleId,
+                ]);
+            }
+        }
+
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $permissionId = DB::table('permissions')->where('name', 'sale.sale_order.billing')->value('id');
+
+        if ($permissionId) {
+            DB::table('role_has_permissions')->where('permission_id', $permissionId)->delete();
+        }
+
+        DB::table('permissions')->where('name', 'sale.sale_order.billing')->delete();
+
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+    }
+};

--- a/database/migrations/2026_04_06_000001_add_production_force_complete_and_check_in_milestone_permissions.php
+++ b/database/migrations/2026_04_06_000001_add_production_force_complete_and_check_in_milestone_permissions.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add production.force_complete permission
+        DB::table('permissions')->insert([
+            'name' => 'production.force_complete',
+            'guard_name' => 'web',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Add production.check_in_milestone permission
+        DB::table('permissions')->insert([
+            'name' => 'production.check_in_milestone',
+            'guard_name' => 'web',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $forceCompleteId = DB::table('permissions')->where('name', 'production.force_complete')->value('id');
+        $checkInMilestoneId = DB::table('permissions')->where('name', 'production.check_in_milestone')->value('id');
+
+        // Assign production.force_complete to roles that had production.complete
+        $completePermission = DB::table('permissions')->where('name', 'production.complete')->first();
+        if ($completePermission) {
+            $roleIds = DB::table('role_has_permissions')
+                ->where('permission_id', $completePermission->id)
+                ->pluck('role_id');
+
+            foreach ($roleIds as $roleId) {
+                $exists = DB::table('role_has_permissions')
+                    ->where('permission_id', $forceCompleteId)
+                    ->where('role_id', $roleId)
+                    ->exists();
+
+                if (! $exists) {
+                    DB::table('role_has_permissions')->insert([
+                        'permission_id' => $forceCompleteId,
+                        'role_id' => $roleId,
+                    ]);
+                }
+            }
+        }
+
+        // Assign production.check_in_milestone to roles that had production.view
+        // (previously check-in had no permission gate, so all production viewers could do it)
+        $viewPermission = DB::table('permissions')->where('name', 'production.view')->first();
+        if ($viewPermission) {
+            $roleIds = DB::table('role_has_permissions')
+                ->where('permission_id', $viewPermission->id)
+                ->pluck('role_id');
+
+            foreach ($roleIds as $roleId) {
+                $exists = DB::table('role_has_permissions')
+                    ->where('permission_id', $checkInMilestoneId)
+                    ->where('role_id', $roleId)
+                    ->exists();
+
+                if (! $exists) {
+                    DB::table('role_has_permissions')->insert([
+                        'permission_id' => $checkInMilestoneId,
+                        'role_id' => $roleId,
+                    ]);
+                }
+            }
+        }
+
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $forceCompleteId = DB::table('permissions')->where('name', 'production.force_complete')->value('id');
+        $checkInMilestoneId = DB::table('permissions')->where('name', 'production.check_in_milestone')->value('id');
+
+        if ($forceCompleteId) {
+            DB::table('role_has_permissions')->where('permission_id', $forceCompleteId)->delete();
+        }
+        if ($checkInMilestoneId) {
+            DB::table('role_has_permissions')->where('permission_id', $checkInMilestoneId)->delete();
+        }
+
+        DB::table('permissions')->where('name', 'production.force_complete')->delete();
+        DB::table('permissions')->where('name', 'production.check_in_milestone')->delete();
+
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+    }
+};

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -105,6 +105,7 @@ class PermissionSeeder extends Seeder
             'sale.sale_order.delete',
             'sale.sale_order.convert_from',
             'sale.sale_order.convert_to',
+            'sale.sale_order.billing',
 
             'sale.cash_sale.view',
             'sale.cash_sale.create',
@@ -162,6 +163,8 @@ class PermissionSeeder extends Seeder
             'production_request.complete',
             'production.cancel',
             'production.complete',
+            'production.force_complete',
+            'production.check_in_milestone',
 
             'ticket.view',
             'ticket.create',

--- a/resources/views/production/view.blade.php
+++ b/resources/views/production/view.blade.php
@@ -155,7 +155,7 @@
             <div class="rounded-lg">
                 <h1 class="font-black text-xl text-blue-900">{{ __('Production ID') }}: {{ $production->sku }}</h1>
                 @if (in_array(strtolower($production->status), ['in progress']) && !($is_sales_only ?? false))
-                    @can('production.complete')
+                    @can('production.force_complete')
                     <x-app.button.button
                         class="font-semibold w-full justify-center mt-2 bg-transparent text-emerald-500 border border-emerald-500 transition duration-250 hover:bg-emerald-500 hover:text-white"
                         id="complete-task-btn">
@@ -245,6 +245,7 @@
         SELECTED_PRODUCTION_MILESTONE_ID = null
         SPAREPART_KEYWORD = {} // productId: keyword
         IS_SALES_ONLY = @json($is_sales_only ?? false);
+        CAN_CHECK_IN_MILESTONE = @json(auth()->user()->can('production.check_in_milestone'));
 
         $(document).ready(function() {
             if (PRODUCTION.status.toLowerCase() != 'in progress') {
@@ -257,7 +258,7 @@
         $('.ms-row').on('click', function(e) {
             e.preventDefault()
 
-            if (IS_SALES_ONLY) return;
+            if (IS_SALES_ONLY || !CAN_CHECK_IN_MILESTONE) return;
 
             let id = $(this).data('id')
             SELECTED_PRODUCTION_MILESTONE_ID = id

--- a/routes/web.php
+++ b/routes/web.php
@@ -469,7 +469,7 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
             Route::get('/get-data', 'getDataSaleOrder')->name('get_data');
             // Route::get('/create', 'createSaleOrder')->name('create')->middleware(['can:sale.sale_order.create']);
             Route::get('/edit/{sale}', 'editSaleOrder')->name('edit')->middleware(['can:sale.sale_order.edit', 'branch.selected']);
-            Route::get('/edit/payment/{sale}', 'editSaleOrder')->name('edit_payment')->middleware(['can:sale.sale_order.edit']);
+            Route::get('/edit/payment/{sale}', 'editSaleOrder')->name('edit_payment')->middleware(['can:sale.sale_order.billing']);
             Route::get('/view/{sale}', 'editSaleOrder')->name('view')->middleware(['can:sale.sale_order.edit']);
             Route::get('/cancel', 'cancelSaleOrder')->name('cancel')->middleware(['can:sale.sale_order.cancel']);
             Route::get('/transfer-back', 'transferBackSaleOrder')->name('transfer_back')->middleware(['can:sale.sale_order.cancel']);
@@ -637,13 +637,13 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
         Route::get('/delete/{production}', 'delete')->name('delete')->middleware(['can:production.delete']);
         Route::get('/quick-duplicate/{production}', 'quickDuplicate')->name('quick_duplicate')->middleware(['can:production.create']);
         Route::post('/upsert/{production?}', 'upsert')->name('upsert');
-        Route::post('/check-in-milestone', 'checkInMilestone')->name('check_in_milestone');
+        Route::post('/check-in-milestone', 'checkInMilestone')->name('check_in_milestone')->middleware('can:production.check_in_milestone');
         Route::post('/reject-milestone', 'rejectMilestone')->name('reject_milestone');
         Route::get('/export', 'export')->name('export');
         Route::get('/to-in-progress', 'toInProgress')->name('to_in_progress');
         Route::get('/generate-barcode', 'generateBarcode')->name('generate_barcode');
         Route::post('/extend-due-date/{production}', 'extendDueDate')->name('extend_due_date');
-        Route::post('/force-complete-task/{production}', 'forceCompleteTask')->name('force_complete_task')->middleware('can:production.complete');
+        Route::post('/force-complete-task/{production}', 'forceCompleteTask')->name('force_complete_task')->middleware('can:production.force_complete');
         Route::post('/cancel/{production}', 'cancelProduction')->name('cancel')->middleware('can:production.cancel');
         Route::post('/add-milestone/{production}', 'addMilestone')->name('add_milestone');
         Route::get('/search-product', 'searchProduct')->name('search_product');


### PR DESCRIPTION
…d production actions

- Add sale.sale_order.billing permission to gate payment form access on sale orders, replacing hardcoded SuperAdmin/Finance role checks in SaleController, ViewServiceProvider, and the edit_payment route middleware
- Add production.force_complete permission to gate the Force Complete Task button and route, replacing the previous reuse of production.complete
- Add production.check_in_milestone permission to gate milestone check-in on the production view page and the check-in-milestone route
- Provide migrations to seed all three permissions and assign them to the appropriate existing roles (billing: SuperAdmin + Finance; force_complete: roles with production.complete; check_in_milestone: roles with production.view)
- Register all three permissions in PermissionSeeder and config/permissions.php