### PR TITLE
feat(service-form): add e-invoice submission and PDF generation tracking

### DIFF
--- a/app/Http/Controllers/EInvoiceController.php
+++ b/app/Http/Controllers/EInvoiceController.php
@@ -23,6 +23,7 @@ use App\Models\Product;
 use App\Models\Sale;
 use App\Models\SaleProduct;
 use App\Models\User;
+use App\Models\ServiceForm;
 use App\Services\EInvoiceXmlGenerator;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
@@ -354,6 +355,160 @@ class EInvoiceController extends Controller
                 'error' => 'Document submission failed',
                 'message' => $th->getMessage(),
             ]);
+        }
+    }
+
+    public function submitServiceForm(Request $request)
+    {
+        $request->validate([
+            'service_form_id' => 'required|string',
+        ]);
+
+        $serviceFormId = \Illuminate\Support\Facades\Crypt::decrypt($request->input('service_form_id'));
+        $serviceForm = ServiceForm::with(['customer', 'customerLocation', 'products', 'einvoice'])->findOrFail($serviceFormId);
+
+        // Check if already submitted
+        if ($serviceForm->einvoice) {
+            return response()->json([
+                'message' => 'E-Invoice has already been submitted for this service form.',
+            ], 400);
+        }
+
+        // Check invoice PDF was generated
+        if (! $serviceForm->generated_invoice) {
+            return response()->json([
+                'message' => 'Please generate the Invoice PDF first before submitting e-invoice.',
+            ], 400);
+        }
+
+        // Determine company from customer
+        $customer = $serviceForm->customer;
+        if (! $customer) {
+            return response()->json([
+                'message' => 'Service form has no customer assigned.',
+            ], 400);
+        }
+
+        $isHiTen = isHiTen($customer->company_group);
+        $company = $isHiTen ? 'hiten' : 'powercool';
+        $tin = $isHiTen ? $this->hitenTin : $this->powerCoolTin;
+        $accessToken = $company == 'powercool' ? $this->accessTokenPowerCool : $this->accessTokenHiten;
+
+        // 72-hour check
+        $now = now();
+        $sfDate = $serviceForm->date;
+        if ($sfDate && $now->diffInHours($sfDate) > 72) {
+            return response()->json([
+                'message' => 'Service form date is older than 72 hours. Please update the date before submitting.',
+            ], 400);
+        }
+
+        $url = 'https://preprod-api.myinvois.hasil.gov.my/api/v1.0/documentsubmissions';
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Accept-Language' => 'en',
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . $accessToken,
+        ];
+
+        try {
+            $document = $this->xmlGenerator->generateServiceFormXml($serviceFormId, $tin);
+
+            $payload = [
+                'documents' => [
+                    [
+                        'format' => 'XML',
+                        'document' => base64_encode($document),
+                        'documentHash' => hash('sha256', $document),
+                        'codeNumber' => $serviceForm->sku,
+                    ],
+                ],
+            ];
+
+            $response = Http::withHeaders($headers)->post($url, $payload);
+            Log::info('e-invoice response for service form ' . $serviceForm->sku, $response->json() ?? []);
+
+            if ($response->successful()) {
+                DB::beginTransaction();
+                try {
+                    $acceptedDocuments = $response->json()['acceptedDocuments'] ?? [];
+                    $rejectedDocuments = $response->json()['rejectedDocuments'] ?? [];
+
+                    if (! empty($rejectedDocuments)) {
+                        $errorDetails = [];
+                        foreach ($rejectedDocuments as $rejectedDoc) {
+                            $errorDetails[] = [
+                                'invoiceCodeNumber' => $rejectedDoc['invoiceCodeNumber'],
+                                'error_code' => $rejectedDoc['error']['code'],
+                                'error_message' => $rejectedDoc['error']['message'],
+                                'error_target' => $rejectedDoc['error']['target'] ?? '',
+                                'details' => array_map(function ($detail) {
+                                    return [
+                                        'code' => $detail['code'],
+                                        'message' => $detail['message'],
+                                        'target' => $detail['target'] ?? '',
+                                        'propertyPath' => $detail['propertyPath'] ?? '',
+                                    ];
+                                }, $rejectedDoc['error']['details'] ?? []),
+                            ];
+                        }
+
+                        DB::rollBack();
+
+                        return response()->json([
+                            'message' => 'E-Invoice submission was rejected.',
+                            'errorDetails' => $errorDetails,
+                        ], 422);
+                    }
+
+                    foreach ($acceptedDocuments as $acceptedDoc) {
+                        $uuid = $acceptedDoc['uuid'];
+                        $documentDetails = $this->getDocumentDetails($uuid, $company);
+
+                        if (isset($documentDetails['error'])) {
+                            DB::rollBack();
+
+                            return response()->json([
+                                'message' => 'Failed to get document details.',
+                                'error' => $documentDetails['error'],
+                            ], 500);
+                        }
+
+                        $serviceForm->einvoice()->create([
+                            'uuid' => $uuid,
+                            'longId' => $documentDetails['longId'],
+                            'status' => 'Valid',
+                            'submission_date' => Carbon::now(),
+                        ]);
+
+                        if (isset($documentDetails['uuid']) && isset($documentDetails['longId'])) {
+                            $this->generateAndSaveEInvoicePdf($documentDetails, $serviceForm->sku);
+                        }
+                    }
+
+                    DB::commit();
+
+                    return response()->json([
+                        'message' => 'E-Invoice submitted successfully for ' . $serviceForm->sku,
+                    ]);
+                } catch (\Throwable $th) {
+                    DB::rollBack();
+
+                    return response()->json([
+                        'message' => 'E-Invoice submission failed: ' . $th->getMessage(),
+                    ], 500);
+                }
+            } else {
+                return response()->json([
+                    'message' => 'E-Invoice submission failed.',
+                    'error' => $response->body(),
+                ], $response->status());
+            }
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'E-Invoice submission failed: ' . $th->getMessage(),
+            ], 500);
         }
     }
 

--- a/app/Http/Controllers/ServiceFormController.php
+++ b/app/Http/Controllers/ServiceFormController.php
@@ -44,7 +44,7 @@ class ServiceFormController extends Controller
     {
         Session::put('service-form-page', $req->page);
 
-        $records = $this->serviceForm->with(['customer', 'technician']);
+        $records = $this->serviceForm->with(['customer', 'technician', 'einvoice']);
 
         // Search
         if ($req->has('search') && $req->search['value'] != null) {
@@ -84,6 +84,11 @@ class ServiceFormController extends Controller
                 'date' => $record->date ? $record->date->format('d M Y') : '-',
                 'customer_name' => $record->customer ? ($record->customer->company_name ?? $record->customer->name) : '-',
                 'technician' => $record->technician ? $record->technician->name : '-',
+                'generated_service_form' => (bool) $record->generated_service_form,
+                'generated_quotation' => (bool) $record->generated_quotation,
+                'generated_cash_sale' => (bool) $record->generated_cash_sale,
+                'generated_invoice' => (bool) $record->generated_invoice,
+                'einvoice_status' => $record->einvoice ? $record->einvoice->status : null,
                 'created_at' => $record->created_at->format('d M Y'),
             ];
         }
@@ -450,6 +455,11 @@ class ServiceFormController extends Controller
         $id = Crypt::decrypt($id);
         $serviceForm = $this->serviceForm::with(['customer', 'customerLocation', 'product', 'serviceItems.product', 'invoice', 'dealer', 'technician'])->findOrFail($id);
 
+        // Mark as generated
+        if (! $serviceForm->generated_service_form) {
+            $serviceForm->update(['generated_service_form' => true]);
+        }
+
         // Prepare customer name
         $customerName = '';
         if ($serviceForm->customer) {
@@ -508,6 +518,11 @@ class ServiceFormController extends Controller
             'technician',
         ])->findOrFail($id);
 
+        // Mark as generated
+        if (! $serviceForm->generated_quotation) {
+            $serviceForm->update(['generated_quotation' => true]);
+        }
+
         // Determine template based on customer's company group
         $isHiTen = $serviceForm->customer && isHiTen($serviceForm->customer->company_group);
         $template = $isHiTen
@@ -562,6 +577,11 @@ class ServiceFormController extends Controller
             'technician',
         ])->findOrFail($id);
 
+        // Mark as generated
+        if (! $serviceForm->generated_cash_sale) {
+            $serviceForm->update(['generated_cash_sale' => true]);
+        }
+
         // Determine template based on customer's company group
         $isHiTen = $serviceForm->customer && isHiTen($serviceForm->customer->company_group);
         $template = $isHiTen
@@ -615,6 +635,11 @@ class ServiceFormController extends Controller
             'paymentMethod',
             'technician',
         ])->findOrFail($id);
+
+        // Mark as generated
+        if (! $serviceForm->generated_invoice) {
+            $serviceForm->update(['generated_invoice' => true]);
+        }
 
         // Determine template based on customer's company group
         $isHiTen = $serviceForm->customer && isHiTen($serviceForm->customer->company_group);

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -279,6 +279,28 @@ class TicketController extends Controller
         ]);
     }
 
+    public function getSaleOrders(Request $req)
+    {
+        $customerId = $req->customer_id;
+
+        $sale_orders = Sale::where('customer_id', $customerId)
+            ->where('type', Sale::TYPE_SO)
+            ->orderBy('id', 'desc')
+            ->get();
+
+        $invoices = Invoice::whereIn('id',
+            DeliveryOrder::where('customer_id', $customerId)
+                ->whereNotNull('invoice_id')
+                ->pluck('invoice_id')
+                ->toArray()
+        )->orderBy('id', 'desc')->get();
+
+        return response()->json([
+            'sale_orders' => $sale_orders,
+            'invoices' => $invoices,
+        ]);
+    }
+
     public function export()
     {
         return Excel::download(new TicketExport, 'ticket.xlsx');

--- a/app/Models/ServiceForm.php
+++ b/app/Models/ServiceForm.php
@@ -100,6 +100,11 @@ class ServiceForm extends Model
         return $this->belongsTo(WarrantyPeriod::class)->withoutGlobalScope(BranchScope::class);
     }
 
+    public function einvoice()
+    {
+        return $this->morphOne(EInvoice::class, 'einvoiceable');
+    }
+
     /**
      * Calculate totals from products
      */

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -367,14 +367,12 @@ class ViewServiceProvider extends ServiceProvider
             $view->with('customers', $customers);
         });
         View::composer(['ticket.form'], function (ViewView $view) {
-            $sale_orders = Sale::where('type', Sale::TYPE_SO)->orderBy('id', 'desc')->get();
-            $invoices = Invoice::orderBy('id', 'desc')->get();
             $products = Product::get();
             $product_children = ProductChild::get();
 
             $view->with([
-                'sale_orders' => $sale_orders,
-                'invoices' => $invoices,
+                'sale_orders' => collect(),
+                'invoices' => collect(),
                 'products' => $products,
                 'product_children' => $product_children,
             ]);

--- a/app/Services/EInvoiceXmlGenerator.php
+++ b/app/Services/EInvoiceXmlGenerator.php
@@ -13,6 +13,8 @@ use App\Models\EInvoice;
 use App\Models\Invoice;
 use App\Models\Product;
 use App\Models\SaleProduct;
+use App\Models\ServiceForm;
+use App\Models\Setting;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
@@ -221,6 +223,250 @@ class EInvoiceXmlGenerator
         Storage::put('/public/e-invoice/'.$invoice->sku.'.xml', $xmlContent);
 
         return $xmlContent;
+    }
+
+    public function generateServiceFormXml($id, $tin)
+    {
+        $serviceForm = ServiceForm::with([
+            'customer',
+            'customerLocation',
+            'products.product.classificationCodes',
+            'paymentMethod',
+        ])->findOrFail($id);
+
+        $customer = $serviceForm->customer;
+        $isHiTen = $customer && isHiTen($customer->company_group);
+        $company = $isHiTen ? 'hiten' : 'powercool';
+
+        $totalDiscount = 0;
+        foreach ($serviceForm->products as $sfProduct) {
+            $totalDiscount += $sfProduct->manualDiscountAmount();
+        }
+
+        // Map payment method name to payment mode code
+        $paymentMethodName = $serviceForm->paymentMethod ? strtolower($serviceForm->paymentMethod->name) : 'cash';
+        $paymentMode = $this->getPaymentModeCode($paymentMethodName);
+
+        $sellerTIN = $tin;
+        $buyerTIN = $customer && $customer->type == 1 ? $customer->tin_number : 'EI000000000020';
+        $buyerIDValue = $customer ? $customer->company_registration_number : 'NA';
+
+        $xml = new \DOMDocument('1.0', 'UTF-8');
+        $xml->formatOutput = true;
+
+        $invoiceElement = $xml->createElement('Invoice');
+        $invoiceElement->setAttribute('xmlns', 'urn:oasis:names:specification:ubl:schema:xsd:Invoice-2');
+        $invoiceElement->setAttribute('xmlns:cac', 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2');
+        $invoiceElement->setAttribute('xmlns:cbc', 'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2');
+        $xml->appendChild($invoiceElement);
+
+        // Invoice number (service form SKU)
+        $cbcId = $xml->createElement('cbc:ID', $serviceForm->sku);
+        $invoiceElement->appendChild($cbcId);
+
+        // Issue date/time
+        $invoiceCreatedAt = new DateTime($serviceForm->date);
+        $invoiceCreatedAt->setTimezone(new DateTimeZone("UTC"));
+        $invoiceCreatedAt->modify('-5 second');
+
+        $currentTime = new DateTime("now", new DateTimeZone("UTC"));
+        $currentTime->modify('-5 second');
+
+        $timeDiff = $currentTime->getTimestamp() - $invoiceCreatedAt->getTimestamp();
+        $hoursDiff = $timeDiff / 3600;
+
+        if ($hoursDiff > 72) {
+            $dateTime = $currentTime;
+        } else {
+            $dateTime = $invoiceCreatedAt;
+        }
+
+        $currentDate = $dateTime->format("Y-m-d");
+        $cbcIssueDate = $xml->createElement('cbc:IssueDate', $currentDate);
+        $invoiceElement->appendChild($cbcIssueDate);
+
+        $currentTimeFormatted = $dateTime->format("H:i:s") . "Z";
+        $cbcIssueTime = $xml->createElement('cbc:IssueTime', $currentTimeFormatted);
+        $invoiceElement->appendChild($cbcIssueTime);
+
+        $invoiceTypeCode = $xml->createElement('cbc:InvoiceTypeCode', '01');
+        $invoiceTypeCode->setAttribute('listVersionID', '1.0');
+        $invoiceElement->appendChild($invoiceTypeCode);
+
+        $currencyCode = $xml->createElement('cbc:DocumentCurrencyCode', 'MYR');
+        $invoiceElement->appendChild($currencyCode);
+
+        $billingReference = $this->createBillingReference($xml, $serviceForm->sku);
+        $invoiceElement->appendChild($billingReference);
+
+        $additionalDocumentReference1 = $this->createAdditionalDocumentReference($xml, 'L1', 'CustomsImportForm');
+        $invoiceElement->appendChild($additionalDocumentReference1);
+
+        $additionalDocumentReference2 = $this->createAdditionalDocumentReference($xml, 'FTA', 'FreeTradeAgreement', 'Sample Description11');
+        $invoiceElement->appendChild($additionalDocumentReference2);
+
+        $additionalDocumentReference3 = $this->createAdditionalDocumentReference($xml, 'L1', 'K2');
+        $invoiceElement->appendChild($additionalDocumentReference3);
+
+        $additionalDocumentReference4 = $this->createAdditionalDocumentReference($xml, 'L1');
+        $invoiceElement->appendChild($additionalDocumentReference4);
+
+        $signatureElement = $this->createSignatureElement(
+            $xml,
+            'urn:oasis:names:specification:ubl:signature:Invoice',
+            'urn:oasis:names:specification:ubl:dsig:enveloped:xades'
+        );
+        $invoiceElement->appendChild($signatureElement);
+
+        $accountingSupplierParty = $this->createAccountingSupplierPartyElement($xml, $sellerTIN, $company);
+        $invoiceElement->appendChild($accountingSupplierParty);
+
+        $accountingCustomerParty = $this->createAccountingCustomerPartyElement($xml, $buyerTIN, $customer, $buyerIDValue);
+        $invoiceElement->appendChild($accountingCustomerParty);
+
+        // Build delivery element using service form's customer info
+        $deliveryElement = $this->createServiceFormDeliveryElement($xml, $serviceForm);
+        $invoiceElement->appendChild($deliveryElement);
+
+        $paymentMeansElement = $this->createPaymentMeansElement($xml, $paymentMode);
+        $invoiceElement->appendChild($paymentMeansElement);
+
+        $allowanceCharge1 = $this->createAllowanceChargeElement($xml, false, 'Total Discount On Products', $totalDiscount);
+        $invoiceElement->appendChild($allowanceCharge1);
+
+        // Calculate totals
+        $sstPercentage = Setting::where('key', Setting::SST_KEY)->value('value') ?? 0;
+        $totals = $serviceForm->calculateTotals((float) $sstPercentage);
+        $paymentAmount = $totals['grand_total'];
+        $taxAmount = $totals['total_tax'];
+        $subtotal = $totals['subtotal'];
+
+        $taxTotal = $this->createTaxTotalElement($xml, $taxAmount, $taxAmount);
+        $invoiceElement->appendChild($taxTotal);
+
+        $legalMonetaryTotal = $this->createLegalMonetaryTotalElement(
+            $xml,
+            $paymentAmount,
+            $paymentAmount,
+            $paymentAmount,
+            $totalDiscount,
+            $subtotal,
+            $paymentAmount,
+        );
+        $invoiceElement->appendChild($legalMonetaryTotal);
+
+        // Invoice lines from service form products
+        foreach ($serviceForm->products as $sfProduct) {
+            if ($sfProduct->is_foc) {
+                continue;
+            }
+
+            $lineExtensionAmount = $sfProduct->qty * $sfProduct->unit_price;
+            $lineTaxPercent = $sfProduct->with_sst ? ((float) $sstPercentage) : 0;
+            $lineTaxAmount = $sfProduct->with_sst ? $sfProduct->calculateSstAmount((float) $sstPercentage) : 0;
+            $description = $sfProduct->getDescription() ?: 'No Description';
+            $itemClassificationCodes = $sfProduct->product ? $sfProduct->product->classificationCodes : collect([ClassificationCode::where('code', '004')->first()]);
+
+            $allowanceCharges = [
+                [
+                    'chargeIndicator' => false,
+                    'reason' => 'Discount on Product',
+                    'amount' => $sfProduct->manualDiscountAmount(),
+                ]
+            ];
+
+            $invoiceLine = $this->createInvoiceLineElement(
+                $xml,
+                (string) $sfProduct->id,
+                $sfProduct->qty,
+                $lineExtensionAmount,
+                $allowanceCharges,
+                $lineTaxAmount,
+                $lineExtensionAmount,
+                $lineTaxPercent,
+                'Exempt New Means of Transport',
+                $description,
+                'MYS',
+                $itemClassificationCodes,
+                $sfProduct->unit_price,
+                $lineExtensionAmount
+            );
+
+            $invoiceElement->appendChild($invoiceLine);
+        }
+
+        $xmlContent = $xml->saveXML();
+        Storage::put('/public/e-invoice/'.$serviceForm->sku.'.xml', $xmlContent);
+
+        return $xmlContent;
+    }
+
+    /**
+     * Create delivery element for service form using customer location data
+     */
+    public function createServiceFormDeliveryElement($xml, $serviceForm)
+    {
+        $customer = $serviceForm->customer;
+        $address = $serviceForm->customerLocation;
+
+        $delivery = $xml->createElement('cac:Delivery');
+        $deliveryParty = $xml->createElement('cac:DeliveryParty');
+
+        $partyIdentifications = [
+            ['schemeID' => 'TIN', 'ID' => $customer->tin_number ?? 'EI00000000010'],
+            ['schemeID' => 'BRN', 'ID' => $customer->company_registration_number ?? 'NA'],
+        ];
+
+        foreach ($partyIdentifications as $identification) {
+            $partyIdentification = $xml->createElement('cac:PartyIdentification');
+            $idElement = $xml->createElement('cbc:ID', $identification['ID']);
+            $idElement->setAttribute('schemeID', $identification['schemeID']);
+            $partyIdentification->appendChild($idElement);
+            $deliveryParty->appendChild($partyIdentification);
+        }
+
+        // Use service form's customer location address
+        $postalAddress = $xml->createElement('cac:PostalAddress');
+        $postalAddress->appendChild($xml->createElement('cbc:CityName', $address->city ?? 'NA'));
+        $postalAddress->appendChild($xml->createElement('cbc:PostalZone', $address->zip_code ?? 'NA'));
+        $postalAddress->appendChild($xml->createElement('cbc:CountrySubentityCode', $address ? ($address->countrySubentityCode() ?? '17') : '17'));
+
+        $addressLines = [];
+        if ($address) {
+            $parts = array_filter([
+                $address->address1 ?? null,
+                $address->address2 ?? null,
+                $address->address3 ?? null,
+                $address->address4 ?? null,
+            ]);
+            $addressLines = ! empty($parts) ? [implode(', ', $parts)] : ['NA'];
+        } else {
+            $addressLines = ['NA'];
+        }
+
+        foreach ($addressLines as $line) {
+            $addressLine = $xml->createElement('cac:AddressLine');
+            $lineElement = $xml->createElement('cbc:Line', $line);
+            $addressLine->appendChild($lineElement);
+            $postalAddress->appendChild($addressLine);
+        }
+
+        $country = $xml->createElement('cac:Country');
+        $identificationCode = $xml->createElement('cbc:IdentificationCode', 'MYS');
+        $identificationCode->setAttribute('listID', 'ISO3166-1');
+        $identificationCode->setAttribute('listAgencyID', '6');
+        $country->appendChild($identificationCode);
+        $postalAddress->appendChild($country);
+
+        $deliveryParty->appendChild($postalAddress);
+
+        $partyLegalEntity = $xml->createElement('cac:PartyLegalEntity');
+        $partyLegalEntity->appendChild($xml->createElement('cbc:RegistrationName', $customer->name ?? 'NA'));
+        $deliveryParty->appendChild($partyLegalEntity);
+
+        $delivery->appendChild($deliveryParty);
+
+        return $delivery;
     }
 
     public function generateConsolidatedXml($id,$consolidated, $tin)

--- a/database/migrations/2026_04_07_000001_add_generated_flags_to_service_forms_table.php
+++ b/database/migrations/2026_04_07_000001_add_generated_flags_to_service_forms_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_forms', function (Blueprint $table) {
+            $table->boolean('generated_service_form')->default(false)->after('grand_total');
+            $table->boolean('generated_quotation')->default(false)->after('generated_service_form');
+            $table->boolean('generated_cash_sale')->default(false)->after('generated_quotation');
+            $table->boolean('generated_invoice')->default(false)->after('generated_cash_sale');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_forms', function (Blueprint $table) {
+            $table->dropColumn([
+                'generated_service_form',
+                'generated_quotation',
+                'generated_cash_sale',
+                'generated_invoice',
+            ]);
+        });
+    }
+};

--- a/resources/views/service_form/list.blade.php
+++ b/resources/views/service_form/list.blade.php
@@ -49,6 +49,10 @@
                     <th>{{ __('Date') }}</th>
                     <th>{{ __('Customer') }}</th>
                     <th>{{ __('Technician') }}</th>
+                    <th class="text-center">{{ __('SF') }}</th>
+                    <th class="text-center">{{ __('QT') }}</th>
+                    <th class="text-center">{{ __('CS') }}</th>
+                    <th class="text-center">{{ __('INV') }}</th>
                     <th>{{ __('Created At') }}</th>
                     <th></th>
                 </tr>
@@ -80,12 +84,16 @@
                 { data: 'date' },
                 { data: 'customer_name' },
                 { data: 'technician' },
+                { data: 'generated_service_form' },
+                { data: 'generated_quotation' },
+                { data: 'generated_cash_sale' },
+                { data: 'generated_invoice' },
                 { data: 'created_at' },
                 { data: 'action' },
             ],
             columnDefs: [
                 {
-                    "width": "12%",
+                    "width": "10%",
                     "targets": 0,
                     orderable: false,
                     render: function(data, type, row) {
@@ -93,7 +101,7 @@
                     }
                 },
                 {
-                    "width": "12%",
+                    "width": "10%",
                     "targets": 1,
                     orderable: false,
                     render: function(data, type, row) {
@@ -101,7 +109,7 @@
                     }
                 },
                 {
-                    "width": "25%",
+                    "width": "18%",
                     "targets": 2,
                     orderable: false,
                     render: function(data, type, row) {
@@ -109,27 +117,88 @@
                     }
                 },
                 {
-                    "width": "15%",
+                    "width": "12%",
                     "targets": 3,
                     orderable: false,
                     render: function(data, type, row) {
                         return data
                     }
                 },
+                // SF column
                 {
-                    "width": "12%",
+                    "width": "4%",
                     "targets": 4,
+                    orderable: false,
+                    className: 'text-center',
+                    render: function(data, type, row) {
+                        return row.generated_service_form
+                            ? `<svg class="h-4 w-4 inline-block text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>`
+                            : `<span class="text-gray-400">-</span>`
+                    }
+                },
+                // QT column
+                {
+                    "width": "4%",
+                    "targets": 5,
+                    orderable: false,
+                    className: 'text-center',
+                    render: function(data, type, row) {
+                        return row.generated_quotation
+                            ? `<svg class="h-4 w-4 inline-block text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>`
+                            : `<span class="text-gray-400">-</span>`
+                    }
+                },
+                // CS column
+                {
+                    "width": "4%",
+                    "targets": 6,
+                    orderable: false,
+                    className: 'text-center',
+                    render: function(data, type, row) {
+                        return row.generated_cash_sale
+                            ? `<svg class="h-4 w-4 inline-block text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>`
+                            : `<span class="text-gray-400">-</span>`
+                    }
+                },
+                // INV column
+                {
+                    "width": "4%",
+                    "targets": 7,
+                    orderable: false,
+                    className: 'text-center',
+                    render: function(data, type, row) {
+                        return row.generated_invoice
+                            ? `<svg class="h-4 w-4 inline-block text-green-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>`
+                            : `<span class="text-gray-400">-</span>`
+                    }
+                },
+                {
+                    "width": "10%",
+                    "targets": 8,
                     orderable: false,
                     render: function(data, type, row) {
                         return data
                     }
                 },
                 {
-                    "width": "12%",
-                    "targets": 5,
+                    "width": "14%",
+                    "targets": 9,
                     "orderable": false,
                     render: function (data, type, row) {
                         let html = `<div class="flex items-center justify-end gap-x-2 px-2">`
+
+                        // Submit E-Invoice Button (only when invoice generated and no e-invoice submitted yet)
+                        if (row.generated_invoice && !row.einvoice_status) {
+                            html += `<button type="button" class="rounded-full p-2 bg-green-200 submit-einvoice-btns" data-id="${row.id}" title="{!! __('Submit E-Invoice') !!}">
+                                <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                            </button>`
+                        }
+
+                        // E-Invoice status badge
+                        if (row.einvoice_status) {
+                            let badgeClass = row.einvoice_status === 'Valid' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+                            html += `<span class="text-xs px-2 py-1 rounded-full ${badgeClass}">${row.einvoice_status}</span>`
+                        }
 
                         // PDF Button
                         html += `<button type="button" class="rounded-full p-2 bg-yellow-200 pdf-btns" data-id="${row.id}" title="{!! __('PDF') !!}">
@@ -187,6 +256,46 @@
             $('#pdf-type-modal #pdf-cash-sale-link').attr('href', `{{ config('app.url') }}/service-form/cash-sale-pdf/${id}`)
             $('#pdf-type-modal #pdf-invoice-link').attr('href', `{{ config('app.url') }}/service-form/invoice-pdf/${id}`)
             $('#pdf-type-modal').addClass('show-modal')
+        })
+
+        // Submit E-Invoice
+        $('#data-table').on('click', '.submit-einvoice-btns', function() {
+            let id = $(this).data('id')
+            let btn = $(this)
+
+            if (!confirm('{!! __("Submit this service form invoice as e-invoice?") !!}')) {
+                return
+            }
+
+            btn.prop('disabled', true)
+
+            $.ajax({
+                url: '{{ config("app.url") }}/service-form/submit-e-invoice',
+                type: 'POST',
+                data: {
+                    _token: '{{ csrf_token() }}',
+                    service_form_id: id,
+                },
+                success: function(res) {
+                    alert(res.message || '{!! __("E-Invoice submitted successfully") !!}')
+                    dt.ajax.reload(null, false)
+                },
+                error: function(xhr) {
+                    let msg = '{!! __("Failed to submit e-invoice") !!}'
+                    if (xhr.responseJSON) {
+                        if (xhr.responseJSON.message) {
+                            msg = xhr.responseJSON.message
+                        }
+                        if (xhr.responseJSON.errorDetails) {
+                            xhr.responseJSON.errorDetails.forEach(function(err) {
+                                msg += '\n' + (err.message || JSON.stringify(err))
+                            })
+                        }
+                    }
+                    alert(msg)
+                    btn.prop('disabled', false)
+                }
+            })
         })
     </script>
 @endpush

--- a/resources/views/ticket/form.blade.php
+++ b/resources/views/ticket/form.blade.php
@@ -218,6 +218,12 @@
             ITEMS_COUNT = $('.items').length
 
             if (ITEMS_COUNT == 0) $('#add-item-btn').click()
+
+            // On edit or old() reload, load sale orders for pre-selected customer
+            let selectedCustomer = $('select[name="customer"]').val()
+            if (selectedCustomer) {
+                loadSaleOrdersForCustomer(selectedCustomer, true)
+            }
         })
 
         $('input[name="attachment[]"]').on('change', function() {
@@ -250,6 +256,13 @@
             $(clone).removeClass('hidden')
             $(clone).removeAttr('id')
 
+            // Copy SO/INV options from the first existing item (if any)
+            let existingSelect = $('.items:first select[name="so_inv[]"]')
+            if (existingSelect.length && existingSelect.find('option').length > 1) {
+                $(clone).find('select[name="so_inv[]"]').html(existingSelect.html())
+                $(clone).find('select[name="so_inv[]"]').val('')
+            }
+
             $('#items-container').append(clone)
         })
         $('body').on('click', '.delete-item-btns', function() {
@@ -265,6 +278,67 @@
             })
         })
 
+
+        // Company changed, get sale orders / invoices
+        $('body').on('change', 'select[name="customer"]', function() {
+            let customerId = $(this).val()
+
+            // Clear all SO/INV, Product, Serial No dropdowns
+            $('select[name="so_inv[]"] option:not(:first)').remove()
+            $('select[name="product[]"] option:not(:first)').remove()
+            $('select[name="serial_no[]"] option:not(:first)').remove()
+            $('input[name="so_inv_type[]"]').val('')
+
+            if (customerId) {
+                loadSaleOrdersForCustomer(customerId, false)
+            }
+        })
+
+        function loadSaleOrdersForCustomer(customerId, preserveSelected) {
+            let url = "{{ config('app.url') }}"
+            url = `${url}/ticket/get-sale-orders?customer_id=${customerId}`
+
+            // Collect currently selected values before loading
+            let selectedValues = {}
+            if (preserveSelected) {
+                $('select[name="so_inv[]"]').each(function(i) {
+                    selectedValues[i] = {
+                        val: $(this).val(),
+                        type: $(this).find('option:checked').data('type')
+                    }
+                })
+            }
+
+            $.ajax({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                },
+                url: url,
+                type: 'GET',
+                contentType: 'application/json',
+                success: function(res) {
+                    $('select[name="so_inv[]"]').each(function(i) {
+                        $(this).find('option:not(:first)').remove()
+
+                        for (let j = 0; j < res.sale_orders.length; j++) {
+                            let opt = new Option(res.sale_orders[j].sku, res.sale_orders[j].id)
+                            $(opt).attr('data-type', 'so')
+                            $(this).append(opt)
+                        }
+                        for (let j = 0; j < res.invoices.length; j++) {
+                            let opt = new Option(res.invoices[j].sku, res.invoices[j].id)
+                            $(opt).attr('data-type', 'inv')
+                            $(this).append(opt)
+                        }
+
+                        // Re-select previously selected value on edit/old() reload
+                        if (preserveSelected && selectedValues[i] && selectedValues[i].val) {
+                            $(this).val(selectedValues[i].val)
+                        }
+                    })
+                }
+            });
+        }
 
         // SO / INV changed, get products
         $('body').on('change', 'select[name="so_inv[]"]', function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -352,6 +352,7 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
         Route::get('/get-invoice-by-keyword', 'getInvoiceByKeyword')->name('get_invoice_by_keyword');
         Route::get('/get-dealer-by-keyword', 'getDealerByKeyword')->name('get_dealer_by_keyword');
         Route::get('/get-product-children', 'getProductChildrenByProduct')->name('get_product_children');
+        Route::post('/submit-e-invoice', [\App\Http\Controllers\EInvoiceController::class, 'submitServiceForm'])->name('submit_e_invoice');
     });
     // GRN
     Route::controller(GRNController::class)->prefix('grn')->name('grn.')->middleware(['can:grn.view'])->group(function () {
@@ -690,6 +691,7 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
         Route::get('/delete/{ticket}', 'delete')->name('delete')->middleware(['can:ticket.delete']);
         Route::get('/get-products', 'getProducts')->name('get_products');
         Route::get('/get-product-children', 'getProductChildren')->name('get_product_children');
+        Route::get('/get-sale-orders', 'getSaleOrders')->name('get_sale_orders');
         Route::get('/export', 'export')->name('export');
     });
     // Report

--- a/tests/Feature/ServiceFormEInvoiceTest.php
+++ b/tests/Feature/ServiceFormEInvoiceTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\CustomerLocation;
+use App\Models\EInvoice;
+use App\Models\ServiceForm;
+use App\Models\ServiceFormProduct;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ServiceFormEInvoiceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function getOrCreateUser(): User
+    {
+        $user = User::first();
+        if ($user) {
+            return $user;
+        }
+
+        return User::create([
+            'name' => 'Test Admin',
+            'email' => 'test_sf_einv@test.com',
+            'password' => Hash::make('password'),
+            'sku' => 'UTEST'.uniqid(),
+        ]);
+    }
+
+    private function getOrCreateCustomer(): Customer
+    {
+        $customer = Customer::first();
+        if ($customer) {
+            return $customer;
+        }
+
+        return Customer::create([
+            'name' => 'Test Customer',
+            'phone' => '0123456789',
+            'sku' => 'CTEST'.uniqid(),
+            'company_group' => 1,
+        ]);
+    }
+
+    private function createServiceForm(array $overrides = []): ServiceForm
+    {
+        $customer = $this->getOrCreateCustomer();
+
+        $sf = ServiceForm::create(array_merge([
+            'sku' => 'SF-TEST-'.uniqid(),
+            'date' => now(),
+            'customer_id' => $customer->id,
+            'generated_service_form' => false,
+            'generated_quotation' => false,
+            'generated_cash_sale' => false,
+            'generated_invoice' => false,
+        ], $overrides));
+
+        return $sf;
+    }
+
+    // ========== Part 1: Generated flags tracking ==========
+
+    public function test_service_form_has_generated_flag_columns()
+    {
+        $sf = $this->createServiceForm();
+
+        $this->assertFalse((bool) $sf->generated_service_form);
+        $this->assertFalse((bool) $sf->generated_quotation);
+        $this->assertFalse((bool) $sf->generated_cash_sale);
+        $this->assertFalse((bool) $sf->generated_invoice);
+    }
+
+    public function test_pdf_endpoint_sets_generated_service_form_flag()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm();
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->get("/service-form/pdf/{$encryptedId}");
+
+        $response->assertStatus(200);
+        $sf->refresh();
+        $this->assertTrue((bool) $sf->generated_service_form);
+        $this->assertFalse((bool) $sf->generated_quotation);
+        $this->assertFalse((bool) $sf->generated_cash_sale);
+        $this->assertFalse((bool) $sf->generated_invoice);
+    }
+
+    public function test_quotation_pdf_sets_generated_quotation_flag()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm();
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->get("/service-form/quotation-pdf/{$encryptedId}");
+
+        $response->assertStatus(200);
+        $sf->refresh();
+        $this->assertTrue((bool) $sf->generated_quotation);
+    }
+
+    public function test_cash_sale_pdf_sets_generated_cash_sale_flag()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm();
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->get("/service-form/cash-sale-pdf/{$encryptedId}");
+
+        $response->assertStatus(200);
+        $sf->refresh();
+        $this->assertTrue((bool) $sf->generated_cash_sale);
+    }
+
+    public function test_invoice_pdf_sets_generated_invoice_flag()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm();
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->get("/service-form/invoice-pdf/{$encryptedId}");
+
+        $response->assertStatus(200);
+        $sf->refresh();
+        $this->assertTrue((bool) $sf->generated_invoice);
+    }
+
+    // ========== Part 1: getData returns flags ==========
+
+    public function test_get_data_returns_generated_flags()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm([
+            'generated_service_form' => true,
+            'generated_invoice' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/service-form/get-data?page=1');
+
+        $response->assertStatus(200);
+        $json = $response->json();
+
+        // Find our service form in the response data
+        $found = collect($json['data'])->first(function ($item) use ($sf) {
+            return $item['sku'] === $sf->sku;
+        });
+
+        $this->assertNotNull($found, 'Service form not found in getData response');
+        $this->assertTrue($found['generated_service_form']);
+        $this->assertFalse($found['generated_quotation']);
+        $this->assertFalse($found['generated_cash_sale']);
+        $this->assertTrue($found['generated_invoice']);
+    }
+
+    // ========== Part 2: E-Invoice submission ==========
+
+    public function test_einvoice_relationship_exists_on_service_form()
+    {
+        $sf = $this->createServiceForm();
+
+        $this->assertNull($sf->einvoice);
+    }
+
+    public function test_submit_einvoice_requires_generated_invoice()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm(['generated_invoice' => false]);
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->postJson('/service-form/submit-e-invoice', [
+            'service_form_id' => $encryptedId,
+        ]);
+
+        $response->assertStatus(400);
+        $response->assertJsonFragment(['message' => 'Please generate the Invoice PDF first before submitting e-invoice.']);
+    }
+
+    public function test_submit_einvoice_requires_customer()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm([
+            'generated_invoice' => true,
+            'customer_id' => null,
+        ]);
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        $response = $this->actingAs($user)->postJson('/service-form/submit-e-invoice', [
+            'service_form_id' => $encryptedId,
+        ]);
+
+        $response->assertStatus(400);
+        $response->assertJsonFragment(['message' => 'Service form has no customer assigned.']);
+    }
+
+    public function test_submit_einvoice_rejects_duplicate_submission()
+    {
+        $user = $this->getOrCreateUser();
+        $sf = $this->createServiceForm(['generated_invoice' => true]);
+        $encryptedId = Crypt::encrypt($sf->id);
+
+        // Create an existing e-invoice for this service form
+        $sf->einvoice()->create([
+            'uuid' => 'test-uuid-'.uniqid(),
+            'longId' => 'test-long-id',
+            'status' => 'Valid',
+            'submission_date' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/service-form/submit-e-invoice', [
+            'service_form_id' => $encryptedId,
+        ]);
+
+        $response->assertStatus(400);
+        $response->assertJsonFragment(['message' => 'E-Invoice has already been submitted for this service form.']);
+    }
+}


### PR DESCRIPTION
- Add generated_service_form, generated_quotation, generated_cash_sale, generated_invoice boolean flags to service_forms table via migration
- Set each flag to true on first PDF generation in ServiceFormController (pdf, quotationPdf, cashSalePdf, invoicePdf endpoints)
- Add einvoice() morphOne relationship to ServiceForm model
- Expose generated flags and einvoice_status in getData() API response, including eager-loading the einvoice relation
- Add EInvoiceController::submitServiceForm() to submit a service form as a UBL XML e-invoice, with guards for duplicate submission, missing invoice PDF, missing customer, and 72-hour date window
- Add EInvoiceXmlGenerator::generateServiceFormXml() and createServiceFormDeliveryElement() to build compliant UBL 2.1 XML from service form data (products, SST, payment method, customer address)
- Add POST /service-form/submit-e-invoice route
- Add GET /ticket/get-sale-orders route backed by TicketController::getSaleOrders(), returning SOs and invoices filtered by customer; remove the global preload from ViewServiceProvider
- Lazy-load SO/INV options in ticket form via AJAX on customer change and on page load when a customer is pre-selected; copy SO/INV options to cloned ticket item rows
- Update service form list view: add SF/QT/CS/INV checkmark columns, submit e-invoice button (shown when invoice generated, no e-invoice yet), and e-invoice status badge; adjust column widths accordingly
- Add ServiceFormEInvoiceTest covering flag defaults, flag-setting per PDF endpoint, getData flag exposure, einvoice relationship, and submission guard conditions (duplicate, missing invoice, missing customer)