### PR TITLE
feat(seed): add UOMSeeder with branch association for KL and Penang

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             PlatformSeeder::class,
             PrioritySeeder::class,
             StateCitySeeder::class,
+            UOMSeeder::class,
         ]);
     }
 }

--- a/database/seeders/UOMSeeder.php
+++ b/database/seeders/UOMSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Branch;
+use App\Models\UOM;
+use Illuminate\Database\Seeder;
+
+class UOMSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $branches = [Branch::LOCATION_KL, Branch::LOCATION_PENANG];
+
+        $uoms = ['MTH', 'PCS', 'TRIP', 'UNIT'];
+
+        foreach ($uoms as $name) {
+            $uom = UOM::withoutGlobalScopes()->updateOrCreate(
+                ['name' => $name],
+                ['is_active' => true]
+            );
+
+            foreach ($branches as $branch) {
+                $existingBranch = Branch::where('object_type', UOM::class)
+                    ->where('object_id', $uom->id)
+                    ->where('location', $branch)
+                    ->first();
+
+                if (!$existingBranch) {
+                    Branch::create([
+                        'object_type' => UOM::class,
+                        'object_id' => $uom->id,
+                        'location' => $branch,
+                    ]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add UOMSeeder seeding MTH, PCS, TRIP, and UNIT units of measure
- Each UOM is linked to KL and Penang branch locations via Branch records
- Use updateOrCreate to keep seeding idempotent
- Register UOMSeeder in DatabaseSeeder run sequence