### PR TITLE
feat(inventory): enforce unique SKU, track created_by on product chil…

### DIFF
--- a/app/Console/Commands/RemoveDuplicateProductChildren.php
+++ b/app/Console/Commands/RemoveDuplicateProductChildren.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DeliveryOrderProductChild;
+use App\Models\GRN;
+use App\Models\ProductChild;
+use App\Models\ProductionMilestoneMaterial;
+use App\Models\SaleProductChild;
+use App\Models\Scopes\BranchScope;
+use App\Models\TaskMilestoneInventory;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveDuplicateProductChildren extends Command
+{
+    protected $signature = 'product-children:dedupe
+                            {--apply : Actually soft-delete the chosen duplicates (default is dry-run)}
+                            {--report= : Write the full report to this TXT path}';
+
+    protected $description = 'Identify and soft-delete duplicate ProductChild rows (same sku, transferred_from IS NULL). Keeps the row that is referenced by downstream records; otherwise keeps the oldest. Skips pairs where both sides are referenced.';
+
+    public function handle(): int
+    {
+        $apply = (bool) $this->option('apply');
+        $reportPath = $this->option('report');
+
+        $this->line($apply ? '[APPLY] Soft-deleting duplicates.' : '[DRY-RUN] No changes will be made. Use --apply to commit.');
+
+        $groups = ProductChild::withoutGlobalScope(BranchScope::class)
+            ->whereNull('deleted_at')
+            ->whereNull('transferred_from')
+            ->select('sku')
+            ->groupBy('sku')
+            ->havingRaw('COUNT(*) > 1')
+            ->pluck('sku');
+
+        if ($groups->isEmpty()) {
+            $this->info('No duplicate SKUs found.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Found {$groups->count()} duplicate SKU groups.");
+
+        $rows = [];
+        $kept = 0;
+        $deleted = 0;
+        $skipped = 0;
+
+        foreach ($groups as $sku) {
+            $dups = ProductChild::withoutGlobalScope(BranchScope::class)
+                ->whereNull('deleted_at')
+                ->whereNull('transferred_from')
+                ->where('sku', $sku)
+                ->orderBy('created_at')
+                ->orderBy('id')
+                ->get();
+
+            $refs = $dups->mapWithKeys(fn ($pc) => [$pc->id => $this->referenceCount($pc->id)]);
+            $referencedIds = $refs->filter(fn ($n) => $n > 0)->keys();
+
+            if ($referencedIds->count() > 1) {
+                foreach ($dups as $pc) {
+                    $rows[] = $this->row($pc, 'SKIP_BOTH_REFERENCED', $refs[$pc->id]);
+                }
+                $skipped += $dups->count();
+                continue;
+            }
+
+            // Keep: referenced one if any, else the oldest (first by created_at, id).
+            $keepId = $referencedIds->first() ?? $dups->first()->id;
+
+            foreach ($dups as $pc) {
+                if ($pc->id === $keepId) {
+                    $rows[] = $this->row($pc, 'KEEP', $refs[$pc->id]);
+                    $kept++;
+                } else {
+                    $rows[] = $this->row($pc, $apply ? 'DELETE' : 'WOULD_DELETE', $refs[$pc->id]);
+                    if ($apply) {
+                        DB::transaction(function () use ($pc) {
+                            ProductChild::withoutGlobalScope(BranchScope::class)
+                                ->where('id', $pc->id)
+                                ->update(['deleted_at' => now()]);
+                        });
+                    }
+                    $deleted++;
+                }
+            }
+        }
+
+        $this->table(
+            ['id', 'sku', 'product_id', 'parent_sku', 'created_at', 'created_by', 'references', 'action'],
+            array_map(fn ($r) => [
+                $r['id'],
+                $r['sku'],
+                $r['product_id'],
+                $r['parent_sku'],
+                $r['created_at'],
+                $r['created_by'],
+                $r['references'],
+                $r['action'],
+            ], $rows)
+        );
+
+        $this->info("Kept: {$kept}");
+        $this->info(($apply ? 'Deleted' : 'Would delete').": {$deleted}");
+        $this->info("Skipped (both referenced): {$skipped}");
+
+        if ($reportPath) {
+            $this->writeTxtReport($reportPath, $rows, $kept, $deleted, $skipped, $apply);
+            $this->info("Report written to {$reportPath}");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function writeTxtReport(string $path, array $rows, int $kept, int $deleted, int $skipped, bool $apply): void
+    {
+        $headers = ['id', 'sku', 'product_id', 'parent_sku', 'created_at', 'created_by', 'references', 'action'];
+        $widths = array_fill_keys($headers, 0);
+        foreach ($headers as $h) {
+            $widths[$h] = strlen($h);
+        }
+        foreach ($rows as $r) {
+            foreach ($headers as $h) {
+                $widths[$h] = max($widths[$h], strlen((string) $r[$h]));
+            }
+        }
+
+        $pad = fn (string $v, string $h) => str_pad($v, $widths[$h], ' ', STR_PAD_RIGHT);
+        $sep = '+';
+        foreach ($headers as $h) {
+            $sep .= str_repeat('-', $widths[$h] + 2).'+';
+        }
+
+        $fh = fopen($path, 'w');
+        fwrite($fh, "Duplicate ProductChildren Report\n");
+        fwrite($fh, 'Generated: '.now()->format('Y-m-d H:i:s')."\n");
+        fwrite($fh, 'Mode: '.($apply ? 'APPLY' : 'DRY-RUN')."\n");
+        fwrite($fh, "Summary: kept={$kept}, ".($apply ? 'deleted' : 'would_delete')."={$deleted}, skipped_both_referenced={$skipped}\n\n");
+
+        fwrite($fh, $sep."\n");
+        $headerLine = '|';
+        foreach ($headers as $h) {
+            $headerLine .= ' '.$pad($h, $h).' |';
+        }
+        fwrite($fh, $headerLine."\n".$sep."\n");
+
+        foreach ($rows as $r) {
+            $line = '|';
+            foreach ($headers as $h) {
+                $line .= ' '.$pad((string) $r[$h], $h).' |';
+            }
+            fwrite($fh, $line."\n");
+        }
+        fwrite($fh, $sep."\n");
+        fclose($fh);
+    }
+
+    private function referenceCount(int $productChildId): int
+    {
+        $count = 0;
+        $count += SaleProductChild::where('product_children_id', $productChildId)->count();
+        $count += DeliveryOrderProductChild::where('product_children_id', $productChildId)->count();
+        $count += ProductionMilestoneMaterial::where('product_child_id', $productChildId)->count();
+        $count += TaskMilestoneInventory::where('inventory_type', ProductChild::class)
+            ->where('inventory_id', $productChildId)
+            ->count();
+        // transferred_from children pointing at this one
+        $count += ProductChild::withoutGlobalScope(BranchScope::class)
+            ->where('transferred_from', $productChildId)
+            ->count();
+        return $count;
+    }
+
+    private function row(ProductChild $pc, string $action, int $references): array
+    {
+        $parentSku = DB::table('products')->where('id', $pc->product_id)->value('sku');
+        $createdBy = $this->guessCreatedBy($pc);
+
+        return [
+            'id' => $pc->id,
+            'sku' => $pc->sku,
+            'product_id' => $pc->product_id,
+            'parent_sku' => $parentSku,
+            'created_at' => (string) $pc->created_at,
+            'created_by' => $createdBy,
+            'references' => $references,
+            'action' => $action,
+        ];
+    }
+
+    // Prefer a real created_by column when present (ProductChild::createdBy()
+    // relation). Otherwise fall back to the closest prior GRN row matching
+    // product_id as a best-effort attribution.
+    private function guessCreatedBy(ProductChild $pc): string
+    {
+        if (Schema::hasColumn('product_children', 'created_by') && $pc->created_by) {
+            $user = $pc->createdBy()->first();
+            return $user ? "{$user->name} (user#{$user->id})" : "user#{$pc->created_by}";
+        }
+
+        $grn = GRN::withoutGlobalScope(BranchScope::class)
+            ->where('product_id', $pc->product_id)
+            ->where('created_at', '<=', $pc->created_at)
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if ($grn === null) {
+            return 'unknown';
+        }
+        return "GRN#{$grn->id}(branch={$grn->branch_id},sku={$grn->sku})";
+    }
+}

--- a/app/Http/Controllers/GRNController.php
+++ b/app/Http/Controllers/GRNController.php
@@ -234,6 +234,44 @@ class GRNController extends Controller
 
     public function stockIn(Request $req)
     {
+        // Collect all submitted serial numbers up-front so we can reject
+        // duplicates (within this submission and against existing rows)
+        // before we start inserting anything.
+        $serialsByProduct = [];
+        $allSerials = [];
+        for ($i = 0; $i < count($req->product); $i++) {
+            $raw = $req->{'serial_no_'.$req->product[$i]};
+            if ($raw == null) {
+                continue;
+            }
+            $serials = array_values(array_filter(array_map('trim', explode(',', $raw)), fn ($s) => $s !== ''));
+            if (count($serials) === 0) {
+                continue;
+            }
+            $serialsByProduct[$i] = $serials;
+            foreach ($serials as $s) {
+                $allSerials[] = $s;
+            }
+        }
+
+        $withinSubmissionDups = array_keys(array_filter(array_count_values($allSerials), fn ($n) => $n > 1));
+        $alreadyExisting = count($allSerials) > 0
+            ? ProductChild::withoutGlobalScope(BranchScope::class)
+                ->whereIn('sku', $allSerials)
+                ->whereNull('transferred_from')
+                ->pluck('sku')
+                ->unique()
+                ->values()
+                ->toArray()
+            : [];
+
+        $offenders = array_values(array_unique(array_merge($withinSubmissionDups, $alreadyExisting)));
+        if (count($offenders) > 0) {
+            return back()
+                ->with('error', 'Duplicate serial number(s): '.implode(', ', $offenders))
+                ->withInput();
+        }
+
         try {
             DB::beginTransaction();
 
@@ -243,7 +281,7 @@ class GRNController extends Controller
                 if ($req->{'serial_no_'.$req->product[$i]} != null) {
                     $grn = $this->grn::where('sku', $req->sku)->where('product_id', $req->product[$i])->first();
 
-                    $serial_no = explode(',', $req->{'serial_no_'.$req->product[$i]});
+                    $serial_no = $serialsByProduct[$i] ?? [];
 
                     for ($j = 0; $j < count($serial_no); $j++) {
                         $data[] = [
@@ -259,6 +297,7 @@ class GRNController extends Controller
                             'product_id' => $req->product[$i],
                             'sku' => $serial_no[$j],
                             'location' => $this->prodChild::LOCATION_WAREHOUSE,
+                            'created_by' => Auth::user()->id,
                         ]);
                     }
                 } elseif ($req->{'qty_'.$req->product[$i]} != null && $req->{'qty_'.$req->product[$i]} != 0) {

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -508,6 +508,7 @@ class ProductController extends Controller
             'data' => [],
             'records_ids' => $records_ids,
         ];
+        $records_paginator->load('createdBy');
         foreach ($records_paginator as $key => $record) {
             $production = null;
             if ($record->location == 'factory') {
@@ -533,6 +534,8 @@ class ProductController extends Controller
                 'stock_out_factory' => $record->stock_out_to_type == Production::class ? ($record->stock_out_to_id == InventoryCategory::FACTORY_17 ? '17' : '22') : null,
                 'done_by' => in_array($record->status, [ProductChild::STATUS_STOCK_OUT, ProductChild::STATUS_PRODUCTION_STOCK_OUT]) ? $record->stockOutBy : ($record->status == ProductChild::STATUS_IN_TRANSIT ? $record->transferredBy : null),
                 'done_at' => in_array($record->status, [ProductChild::STATUS_STOCK_OUT, ProductChild::STATUS_PRODUCTION_STOCK_OUT]) ? Carbon::parse($record->stock_out_at)->format('d M Y, h:i A') : ($record->status == ProductChild::STATUS_IN_TRANSIT ? Carbon::parse($record->stock_out_at)->format('d M Y, h:i A') : null),
+                'created_by' => $record->createdBy,
+                'created_at' => $record->created_at != null ? Carbon::parse($record->created_at)->format('d M Y, h:i A') : null,
                 'progress' => $record->location != 'factory' || $production == null ? null : $production->getProgress($production),
                 'remark' => $record->reject_reason ?? null,
             ];
@@ -1023,6 +1026,7 @@ class ProductController extends Controller
                             'product_id' => $prod->id,
                             'sku' => $req->serial_no[$i],
                             'location' => $this->prodChild::LOCATION_WAREHOUSE,
+                            'created_by' => Auth::user()->id,
                             'created_at' => $now,
                             'updated_at' => $now,
                         ];

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -1095,6 +1095,7 @@ class ProductionController extends Controller
                     'product_id' => $prod->id,
                     'sku' => ($this->productChild)->generateSku($prod->initial_for_production ?? $prod->sku),
                     'location' => $this->productChild::LOCATION_FACTORY,
+                    'created_by' => Auth::user()->id,
                 ]);
 
                 $productions[$i]->product_child_id = $prodChild->id;

--- a/app/Models/ProductChild.php
+++ b/app/Models/ProductChild.php
@@ -57,6 +57,32 @@ class ProductChild extends Model
         return $date;
     }
 
+    protected static function booted(): void
+    {
+        // Enforce SKU uniqueness on active (non-soft-deleted) originals.
+        // Branch-transfer replicas (transferred_from != null) are exempt —
+        // they intentionally mirror the source row's SKU across branches.
+        static::creating(function (self $child) {
+            if ($child->sku === null || $child->sku === '') {
+                return;
+            }
+            if ($child->transferred_from !== null) {
+                return;
+            }
+
+            $exists = static::withoutGlobalScope(BranchScope::class)
+                ->where('sku', $child->sku)
+                ->whereNull('transferred_from')
+                ->exists();
+
+            if ($exists) {
+                throw new \RuntimeException(
+                    "Duplicate product_children.sku: {$child->sku}"
+                );
+            }
+        });
+    }
+
     public function parent()
     {
         return $this->belongsTo(Product::class, 'product_id');
@@ -80,6 +106,11 @@ class ProductChild extends Model
     public function stockOutBy()
     {
         return $this->belongsTo(User::class, 'stock_out_by')->withoutGlobalScope(BranchScope::class);
+    }
+
+    public function createdBy()
+    {
+        return $this->belongsTo(User::class, 'created_by')->withoutGlobalScope(BranchScope::class);
     }
 
     public function transferredBy()
@@ -150,7 +181,6 @@ class ProductChild extends Model
         $init_idx = 1;
         $sku = null;
         $min_char = 6;
-        $existing_skus = self::pluck('sku')->toArray();
 
         while (true) {
             $str_init_idx = (string) $init_idx;
@@ -159,7 +189,12 @@ class ProductChild extends Model
             }
             $sku = $parent_prefix.'-'.now()->format('ymd').'-'.$str_init_idx;
 
-            if (! in_array($sku, $existing_skus)) {
+            // Re-query per candidate (the previous version cached results once
+            // before the loop, which let concurrent callers collide).
+            $taken = self::withoutGlobalScope(BranchScope::class)
+                ->where('sku', $sku)
+                ->exists();
+            if (! $taken) {
                 break;
             }
 

--- a/database/migrations/2026_04_22_150159_add_created_by_on_product_children_table.php
+++ b/database/migrations/2026_04_22_150159_add_created_by_on_product_children_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('product_children', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable()->after('stock_out_at');
+            $table->foreign('created_by')->on('users')->references('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('product_children', function (Blueprint $table) {
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+};

--- a/resources/views/inventory/view.blade.php
+++ b/resources/views/inventory/view.blade.php
@@ -207,6 +207,7 @@
                                 <th>{{ __('Assigned Order ID') }}</th>
                                 <th>{{ __('Status') }}</th>
                                 <th>{{ __('Done By') }}</th>
+                                <th>{{ __('Created By') }}</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -462,6 +463,9 @@
                             data: 'done_by'
                         },
                         {
+                            data: 'created_by'
+                        },
+                        {
                             data: 'action'
                         },
                     ],
@@ -536,6 +540,16 @@
                         {
                             "width": "5%",
                             "targets": 6,
+                            orderable: false,
+                            render: function(data, type, row) {
+                                if (data != null)
+                                    return `<span class="text-sm font-semibold">${data.name}</span><br><span class="text-xs">${row.created_at ?? ''}</span>`
+                                return row.created_at ?? '-'
+                            }
+                        },
+                        {
+                            "width": "5%",
+                            "targets": 7,
                             orderable: false,
                             render: function(data, type, row) {
                                 console.log(row)

--- a/tests/Feature/ProductChildCreatedByTest.php
+++ b/tests/Feature/ProductChildCreatedByTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InventoryCategory;
+use App\Models\Product;
+use App\Models\ProductChild;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ProductChildCreatedByTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function makeProduct(): Product
+    {
+        return Product::create([
+            'inventory_category_id' => InventoryCategory::first()->id,
+            'type' => Product::TYPE_PRODUCT,
+            'sku' => 'TEST-CB-'.uniqid(),
+            'model_desc' => 'Created-By Test',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_product_child_persists_created_by_and_created_at(): void
+    {
+        $user = User::first();
+        $this->assertNotNull($user, 'Seeded user required for this test');
+
+        $product = $this->makeProduct();
+
+        $child = ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => 'SN-CB-'.uniqid(),
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+            'created_by' => $user->id,
+        ]);
+
+        $child->refresh();
+
+        $this->assertSame($user->id, (int) $child->created_by);
+        $this->assertNotNull($child->created_at);
+    }
+
+    public function test_created_by_relationship_returns_user(): void
+    {
+        $user = User::first();
+        $this->assertNotNull($user);
+
+        $product = $this->makeProduct();
+
+        $child = ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => 'SN-CB-REL-'.uniqid(),
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+            'created_by' => $user->id,
+        ]);
+
+        $this->assertInstanceOf(User::class, $child->createdBy);
+        $this->assertSame($user->id, $child->createdBy->id);
+    }
+
+    public function test_created_by_is_nullable(): void
+    {
+        $product = $this->makeProduct();
+
+        $child = ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => 'SN-CB-NULL-'.uniqid(),
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+
+        $child->refresh();
+
+        $this->assertNull($child->created_by);
+        $this->assertNull($child->createdBy);
+    }
+}

--- a/tests/Feature/ProductChildUniqueSkuTest.php
+++ b/tests/Feature/ProductChildUniqueSkuTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InventoryCategory;
+use App\Models\Product;
+use App\Models\ProductChild;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ProductChildUniqueSkuTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function makeProduct(string $suffix): Product
+    {
+        return Product::create([
+            'inventory_category_id' => InventoryCategory::first()->id,
+            'type' => Product::TYPE_PRODUCT,
+            'sku' => 'TEST-SKU-DUP-'.$suffix.'-'.uniqid(),
+            'model_desc' => 'Test '.$suffix,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_rejects_duplicate_sku_on_same_product(): void
+    {
+        $product = $this->makeProduct('same');
+        $sku = 'SERIAL-'.uniqid();
+
+        ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Duplicate product_children\.sku/');
+
+        ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+    }
+
+    public function test_rejects_duplicate_sku_across_different_products(): void
+    {
+        $productA = $this->makeProduct('A');
+        $productB = $this->makeProduct('B');
+        $sku = 'SERIAL-'.uniqid();
+
+        ProductChild::create([
+            'product_id' => $productA->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+
+        ProductChild::create([
+            'product_id' => $productB->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+    }
+
+    public function test_allows_branch_transfer_replica_to_share_sku(): void
+    {
+        $productA = $this->makeProduct('src');
+        $productB = $this->makeProduct('dst');
+        $sku = 'SERIAL-'.uniqid();
+
+        $original = ProductChild::create([
+            'product_id' => $productA->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+
+        // Branch-transfer replica: carries transferred_from, so it's exempt.
+        $replica = ProductChild::create([
+            'product_id' => $productB->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+            'transferred_from' => $original->id,
+        ]);
+
+        $this->assertNotNull($replica->id);
+        $this->assertSame($sku, $replica->sku);
+    }
+
+    public function test_allows_reuse_after_soft_delete(): void
+    {
+        // Guard shouldn't block: the previous row is soft-deleted but still
+        // physically present, yet SKU must be reusable for a fresh unit.
+        // Current rule uses withoutGlobalScope(BranchScope) but respects the
+        // model's default SoftDeletes scope, so soft-deleted rows are skipped.
+        $product = $this->makeProduct('reuse');
+        $sku = 'SERIAL-'.uniqid();
+
+        $first = ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+        $first->delete();
+
+        $second = ProductChild::create([
+            'product_id' => $product->id,
+            'sku' => $sku,
+            'location' => ProductChild::LOCATION_WAREHOUSE,
+        ]);
+
+        $this->assertNotNull($second->id);
+    }
+}


### PR DESCRIPTION
…dren

- Add migration to add nullable created_by FK column on product_children
- Add ProductChild::booted() guard that throws RuntimeException on duplicate SKU (original rows only; branch-transfer replicas are exempt)
- Fix generateSku() race condition: re-query per candidate instead of caching a snapshot before the loop
- Record created_by (Auth::user()->id) in GRNController, ProductController, and ProductionController when creating product children
- Add createdBy() BelongsTo relation on ProductChild model
- Expose created_by and created_at in ProductController::viewGetData() with eager-loaded relation
- Show "Created By" column in inventory view table with user name and date
- Add GRNController pre-flight duplicate-SKU check before any DB writes
- Add Artisan command product-children:dedupe (dry-run default, --apply, --report)
- Add Feature tests: ProductChildCreatedByTest and ProductChildUniqueSkuTest