### PR TITLE
feat(permissions): add grn.stock_in permission and guard inventory ac…

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -281,7 +281,7 @@ class ProductController extends Controller
                 'sku' => $record->sku,
                 'image' => $record->images->first(),
                 'model_desc' => $record->model_desc,
-                'category' => $record->category->name,
+                'category' => $record->category?->name,
                 'qty' => $qty,
                 'has_factory_child' => $record->orWhereHas('children', function ($qq) {
                     $qq->where('location', ProductChild::LOCATION_FACTORY);

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -56,6 +56,7 @@ return [
     'grn.edit' => 'Update goods received note details',
     'grn.cancel' => 'Show the Cancel button on GRN rows to void a goods received note',
     'grn.delete' => 'Show the Delete button on GRN rows to soft-delete a goods received note',
+    'grn.stock_in' => 'Allow performing the Stock In action on a GRN to receive goods into the warehouse',
 
     // Service Reminder
     'service_reminder.view' => 'Show the Service Reminder menu under After Service and access the service reminder listing page',

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -68,6 +68,7 @@ class PermissionSeeder extends Seeder
             'grn.edit',
             'grn.cancel',
             'grn.delete',
+            'grn.stock_in',
 
             'service_reminder.view',
             'service_reminder.create',

--- a/resources/views/grn/form.blade.php
+++ b/resources/views/grn/form.blade.php
@@ -103,7 +103,7 @@
                     </svg>
                     <span class="text-sm">{{ __('Add Item') }}</span>
                 </button>
-                @if (isset($sku))
+                @if (isset($sku) && hasPermission('grn.stock_in'))
                     <button type="button" class="bg-yellow-400 rounded-md py-1.5 px-3 flex items-center gap-x-2 transition duration-300 hover:bg-yellow-300 hover:shadow" id="stock-in-btn">
                         <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="0 0 24 24" width="512" height="512"><path d="M21,12h-3c-1.103,0-2,.897-2,2s-.897,2-2,2h-4c-1.103,0-2-.897-2-2s-.897-2-2-2H3c-1.654,0-3,1.346-3,3v4c0,2.757,2.243,5,5,5h14c2.757,0,5-2.243,5-5v-4c0-1.654-1.346-3-3-3Zm1,7c0,1.654-1.346,3-3,3H5c-1.654,0-3-1.346-3-3v-4c0-.552,.448-1,1-1l3-.002v.002c0,2.206,1.794,4,4,4h4c2.206,0,4-1.794,4-4h3c.552,0,1,.448,1,1v4ZM7.293,7.121c-.391-.391-.391-1.023,0-1.414s1.023-.391,1.414,0l2.293,2.293V1c0-.553,.447-1,1-1s1,.447,1,1v7l2.293-2.293c.391-.391,1.023-.391,1.414,0s.391,1.023,0,1.414l-3.293,3.293c-.387,.387-.896,.582-1.405,.584l-.009,.002-.009-.002c-.509-.002-1.018-.197-1.405-.584l-3.293-3.293Z"/></svg>
                         <span class="text-sm">{{ __('Stock In') }}</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -285,10 +285,10 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
         Route::post('/upsert', 'upsert')->name('upsert');
         Route::get('/delete/{cat}', 'delete')->name('delete')->middleware(['can:inventory.category.delete']);
 
-        Route::get('/stock-in/{product_child}', 'stockIn')->name('stock_in');
-        Route::get('/stock-out/{product_child}', 'stockOut')->name('stock_out');
-        Route::get('/transfer/{product_child}', 'transfer')->name('transfer');
-        Route::get('/to-warehouse/{product_child}', 'toWarehouse')->name('to_warehouse');
+        Route::get('/stock-in/{product_child}', 'stockIn')->name('stock_in')->middleware(['can:inventory.view_action']);
+        Route::get('/stock-out/{product_child}', 'stockOut')->name('stock_out')->middleware(['can:inventory.view_action']);
+        Route::get('/transfer/{product_child}', 'transfer')->name('transfer')->middleware(['can:inventory.view_action']);
+        Route::get('/to-warehouse/{product_child}', 'toWarehouse')->name('to_warehouse')->middleware(['can:inventory.view_action']);
         Route::get('/accept-production-stock-out/{product_child}', 'acceptProductionStockOut');
         Route::get('/reject-production-stock-out/{product_child}', 'rejectProductionStockOut');
         Route::get('/accept-production-stock-out-rm/{frm}', 'acceptProductionStockOutRM');
@@ -363,7 +363,7 @@ Route::middleware('auth', 'select_lang', 'notification', 'approval')->group(func
         Route::get('/edit/{sku}', 'edit')->name('edit')->middleware(['can:grn.create', 'branch.selected'])->where('sku', '.*');
         Route::post('/upsert', 'upsert')->name('upsert');
         Route::get('/pdf/{sku}', 'pdf')->name('pdf')->where('sku', '.*');
-        Route::post('/stock-in', 'stockIn')->name('stock_in');
+        Route::post('/stock-in', 'stockIn')->name('stock_in')->middleware(['can:grn.stock_in']);
         Route::post('/sync', 'sync')->name('sync');
         Route::post('/cancel/{sku}', 'cancel')->name('cancel')->middleware(['can:grn.cancel'])->where('sku', '.*');
         Route::post('/delete/{sku}', 'delete')->name('delete')->middleware(['can:grn.delete'])->where('sku', '.*');

--- a/tests/Feature/GrnStockInPermissionTest.php
+++ b/tests/Feature/GrnStockInPermissionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class GrnStockInPermissionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function ensurePermissions(): void
+    {
+        Permission::firstOrCreate(['name' => 'grn.view', 'guard_name' => 'web']);
+        Permission::firstOrCreate(['name' => 'grn.stock_in', 'guard_name' => 'web']);
+    }
+
+    public function test_user_with_grn_view_only_cannot_stock_in(): void
+    {
+        $this->ensurePermissions();
+
+        $user = User::factory()->create();
+        $user->givePermissionTo('grn.view');
+        $this->actingAs($user);
+
+        $response = $this->post(route('grn.stock_in'));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_with_grn_stock_in_permission_passes_the_gate(): void
+    {
+        $this->ensurePermissions();
+
+        $user = User::factory()->create();
+        $user->givePermissionTo(['grn.view', 'grn.stock_in']);
+        $this->actingAs($user);
+
+        $response = $this->post(route('grn.stock_in'));
+
+        $this->assertNotEquals(
+            403,
+            $response->status(),
+            'User with grn.stock_in must not be blocked by the can:grn.stock_in gate'
+        );
+    }
+}

--- a/tests/Feature/InventoryActionPermissionTest.php
+++ b/tests/Feature/InventoryActionPermissionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ProductChild;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class InventoryActionPermissionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function aProductChildId(): int
+    {
+        $pc = ProductChild::first();
+        $this->assertNotNull($pc, 'Expected at least one ProductChild in the test DB');
+
+        return $pc->id;
+    }
+
+    private function userWithCategoryViewOnly(): User
+    {
+        Permission::firstOrCreate(['name' => 'inventory.category.view', 'guard_name' => 'web']);
+        Permission::firstOrCreate(['name' => 'inventory.view_action', 'guard_name' => 'web']);
+
+        $user = User::factory()->create();
+        $user->givePermissionTo('inventory.category.view');
+
+        return $user;
+    }
+
+    public function test_stock_in_requires_inventory_view_action(): void
+    {
+        $this->actingAs($this->userWithCategoryViewOnly());
+
+        $response = $this->get(route('inventory_category.stock_in', $this->aProductChildId()));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_stock_out_requires_inventory_view_action(): void
+    {
+        $this->actingAs($this->userWithCategoryViewOnly());
+
+        $response = $this->get(route('inventory_category.stock_out', $this->aProductChildId()));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_transfer_requires_inventory_view_action(): void
+    {
+        $this->actingAs($this->userWithCategoryViewOnly());
+
+        $response = $this->get(route('inventory_category.transfer', $this->aProductChildId()));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_to_warehouse_requires_inventory_view_action(): void
+    {
+        $this->actingAs($this->userWithCategoryViewOnly());
+
+        $response = $this->get(route('inventory_category.to_warehouse', $this->aProductChildId()));
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
…tion routes

- Add new `grn.stock_in` permission to config/permissions.php and PermissionSeeder
- Gate the GRN stock-in route (POST /stock-in) behind `can:grn.stock_in` middleware
- Conditionally show the Stock In button in grn/form.blade.php only when the user has grn.stock_in
- Guard all four inventory category action routes (stock-in, stock-out, transfer, to-warehouse) behind `can:inventory.view_action`
- Fix nullable category access in ProductController::getData to avoid null-pointer errors
- Add GrnStockInPermissionTest to verify 403 without permission and non-403 with permission
- Add InventoryActionPermissionTest to verify all four action routes reject users lacking inventory.view_action