### PR TITLE
feat(customer,supplier): replace identity_type free-text with enum se…

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -325,7 +325,7 @@ class CustomerController extends Controller
             'prev_gst_reg_no' => 'nullable|max:250',
             'registered_name' => 'nullable|max:250',
             'trade_name' => 'nullable|max:250',
-            'identity_type' => 'nullable|max:250',
+            'identity_type' => 'nullable|in:MyKAD,MyPR,MyKAS,ARMY,PASSPORT',
             'identity_no' => 'nullable|max:250',
             'address' => 'nullable|max:250',
             'city' => 'nullable|max:250',

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -172,7 +172,7 @@ class SupplierController extends Controller
             'prev_gst_reg_no' => 'nullable|max:250',
             'registered_name' => 'required|max:250',
             'trade_name' => 'nullable|max:250',
-            'identity_type' => 'required_if:category,==,2|max:250',
+            'identity_type' => 'required_if:category,==,2|in:MyKAD,MyPR,MyKAS,ARMY,PASSPORT',
             'identity_no' => 'nullable|max:250',
         ], [
             'required_if' => 'The :attribute is required',

--- a/resources/views/customer/form_step/info.blade.php
+++ b/resources/views/customer/form_step/info.blade.php
@@ -98,8 +98,15 @@
                 <x-app.input.label id="identity_type" class="mb-1">{{ __('Identity Type') }}
                     <span class="text-sm text-red-500 hidden for_einvoice-required">*</span>
                 </x-app.input.label>
-                <x-app.input.input name="identity_type" id="identity_type" class="uppercase-input" :hasError="$errors->has('identity_type')"
-                    value="{{ old('identity_type', isset($duplicate) ? $duplicate->identity_type : (isset($customer) ? $customer->identity_type : null)) }}" />
+                @php
+                    $selectedIdentityType = old('identity_type', isset($duplicate) ? $duplicate->identity_type : (isset($customer) ? $customer->identity_type : null));
+                @endphp
+                <x-app.input.select name="identity_type" id="identity_type" :hasError="$errors->has('identity_type')">
+                    <option value="">{{ __('Select identity type') }}</option>
+                    @foreach (['MyKAD', 'MyPR', 'MyKAS', 'ARMY', 'PASSPORT'] as $opt)
+                        <option value="{{ $opt }}" @selected($selectedIdentityType === $opt)>{{ $opt }}</option>
+                    @endforeach
+                </x-app.input.select>
                 <x-app.message.error id="identity_type_err" />
             </div>
             <div class="flex flex-col hidden individual-fields-container">

--- a/resources/views/customer/form_step/location.blade.php
+++ b/resources/views/customer/form_step/location.blade.php
@@ -34,6 +34,16 @@
                     <p class="text-xs text-blue-700 border border-blue-700 p-1.5 rounded shadow">
                         {{ __('Default Billing & Delivery Address') }}</p>
                 </div>
+                <div class="col-span-2 md:col-span-4 flex justify-end">
+                    <button type="button"
+                        class="set-identical-btn bg-yellow-400 rounded-md py-1 px-2 text-sm flex items-center gap-x-1 transition duration-300 hover:bg-yellow-300 hover:shadow"
+                        title="{{ __('Copy main address into this location') }}">
+                        <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/>
+                        </svg>
+                        <span>{{ __('Set Identical') }}</span>
+                    </button>
+                </div>
                 <div class="flex flex-col">
                     <x-app.input.label id="address1" class="mb-1">{{ __('Address 1') }}</x-app.input.label>
                     <x-app.input.input name="address1" id="address1" :hasError="$errors->has('address1')" />
@@ -160,6 +170,26 @@
             $(clone).removeAttr('id')
 
             $('#items-container').append(clone)
+        })
+        $('body').on('click', '.set-identical-btn', function() {
+            let $item = $(this).closest('.items')
+            let $info = $('#info-form')
+
+            let mainAddress = $info.find('input[name="address"]').val() ?? ''
+            let mainCity = $info.find('input[name="city"]').val() ?? ''
+            let mainZip = $info.find('input[name="zip_code"]').val() ?? ''
+
+            let $stateSel = $info.find('select[name="state"]')
+            let $countrySel = $info.find('select[name="country"]')
+            let mainStateText = ($stateSel.val() ?? '') === '' ? '' : $stateSel.find('option:selected').text().trim()
+            let mainCountryText = ($countrySel.val() ?? '') === '' ? '' : $countrySel.find('option:selected').text().trim()
+
+            let cityZip = [mainCity, mainZip].filter(s => s && s.length > 0).join(' ')
+
+            $item.find('input[name="address1"]').val(mainAddress)
+            $item.find('input[name="address2"]').val(cityZip)
+            $item.find('input[name="address3"]').val(mainStateText)
+            $item.find('input[name="address4"]').val(mainCountryText)
         })
         $('body').on('click', '.delete-item-btns', function() {
             let id = $(this).data('id')

--- a/resources/views/supplier/form.blade.php
+++ b/resources/views/supplier/form.blade.php
@@ -73,9 +73,17 @@
                     <x-app.input.input name="prev_gst_reg_no" id="prev_gst_reg_no" class="uppercase-input" :hasError="$errors->has('prev_gst_reg_no')" value="{{ old('prev_gst_reg_no', isset($supplier) ? $supplier->prev_gst_reg_no : null) }}"/>
                     <x-input-error :messages="$errors->get('prev_gst_reg_no')" class="mt-2" />
                 </div>
-                <div class="flex flex-col hidden individual-fields-container"">
+                <div class="flex flex-col hidden individual-fields-container">
                     <x-app.input.label id="identity_type" class="mb-1">{{ __('Identity Type') }} <span class="text-sm text-red-500">*</span></x-app.input.label>
-                    <x-app.input.input name="identity_type" id="identity_type" class="uppercase-input" :hasError="$errors->has('identity_type')" value="{{ old('identity_type', isset($supplier) ? $supplier->identity_type : null) }}"/>
+                    @php
+                        $selectedIdentityType = old('identity_type', isset($supplier) ? $supplier->identity_type : null);
+                    @endphp
+                    <x-app.input.select name="identity_type" id="identity_type" :hasError="$errors->has('identity_type')">
+                        <option value="">{{ __('Select identity type') }}</option>
+                        @foreach (['MyKAD', 'MyPR', 'MyKAS', 'ARMY', 'PASSPORT'] as $opt)
+                            <option value="{{ $opt }}" @selected($selectedIdentityType === $opt)>{{ $opt }}</option>
+                        @endforeach
+                    </x-app.input.select>
                     <x-input-error :messages="$errors->get('identity_type')" class="mt-2" />
                 </div>
                 <div class="flex flex-col hidden individual-fields-container"">


### PR DESCRIPTION
…lect and add "Set Identical" address copy

- Constrain identity_type to allowed values (MyKAD, MyPR, MyKAS, ARMY, PASSPORT) via backend validation in CustomerController and SupplierController
- Replace free-text identity_type inputs with <select> dropdowns in customer info form and supplier form, preserving old/model-bound selection state
- Fix double-quote typo in supplier form individual-fields-container div attribute
- Add "Set Identical" button on each customer location entry that copies the main address (address, city, zip, state, country) into the location's address fields