### PR TITLE
feat(production,vehicle): bulk quick-duplicate, Van/Motor types, and …

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -646,105 +646,122 @@ class ProductionController extends Controller
         }
     }
 
-    public function quickDuplicate(Production $production)
+    public function quickDuplicate(Request $req, Production $production)
     {
+        $req->validate([
+            'qty' => ['nullable', 'integer', 'min:1', 'max:20'],
+        ]);
+        $qty = (int) ($req->qty ?? 1);
+
         try {
             DB::beginTransaction();
 
             $production->load(['users', 'milestones']);
 
-            // Create new production
-            $newProduction = Production::create([
-                'sku' => $this->prod->generateSku(),
-                'product_id' => $production->product_id,
-                'sale_id' => $production->sale_id,
-                'name' => $production->name,
-                'desc' => $production->desc,
-                'remark' => $production->remark,
-                'start_date' => now()->format('Y-m-d'),
-                'due_date' => $production->due_date != null && $production->start_date != null
-                    ? now()->addDays(Carbon::parse($production->start_date)->diffInDays(Carbon::parse($production->due_date)))->format('Y-m-d')
-                    : null,
-                'status' => Production::STATUS_TO_DO,
-                'type' => $production->type,
-                'priority_id' => $production->priority_id,
-                'factory_id' => $production->factory_id,
-            ]);
-            (new Branch)->assign(Production::class, $newProduction->id);
-
-            // Copy user assignments
-            foreach ($production->users as $user) {
-                UserProduction::create([
-                    'user_id' => $user->id,
-                    'production_id' => $newProduction->id,
-                ]);
-            }
-
-            // Copy milestones and material previews
-            foreach ($production->milestones as $milestone) {
-                $newProdMs = ProductionMilestone::create([
-                    'production_id' => $newProduction->id,
-                    'milestone_id' => $milestone->id,
-                    'sequence' => $milestone->pivot->sequence ?? 1,
-                ]);
-
-                // Copy material preview records
-                $oldProdMsId = ProductionMilestone::where('production_id', $production->id)
-                    ->where('milestone_id', $milestone->id)
-                    ->value('id');
-
-                if ($oldProdMsId) {
-                    $previews = ProductionMilestoneMaterialPreview::where('production_milestone_id', $oldProdMsId)->get();
-                    foreach ($previews as $preview) {
-                        ProductionMilestoneMaterialPreview::create([
-                            'production_milestone_id' => $newProdMs->id,
-                            'product_id' => $preview->product_id,
-                            'qty' => $preview->qty,
-                        ]);
-                    }
-                }
-            }
-
-            // Create Raw Material Request
-            if ($production->type != Production::TYPE_RND) {
-                $materialUse = MaterialUse::with('materials')->where('product_id', $production->product_id)->first();
-                if ($materialUse != null) {
-                    $rmq = RawMaterialRequest::create([
-                        'production_id' => $newProduction->id,
-                        'material_use_id' => $materialUse->id,
-                        'status' => RawMaterialRequest::STATUS_IN_PROGRESS,
-                        'requested_by' => Auth::user()->id,
-                    ]);
-                    (new Branch)->assign(RawMaterialRequest::class, $rmq->id);
-
-                    $data = [];
-                    foreach ($materialUse->materials as $material) {
-                        $data[] = [
-                            'raw_material_request_id' => $rmq->id,
-                            'product_id' => $material->product_id,
-                            'status' => RawMaterialRequestMaterial::MATERIAL_STATUS_IN_PROGRESS,
-                            'qty' => $material->material->is_sparepart ? 1 : $material->qty,
-                            'created_at' => now(),
-                        ];
-                    }
-                    RawMaterialRequestMaterial::insert($data);
-                }
-
-                // Set product in_production flag
-                Product::where('id', $production->product_id)->update([
-                    'in_production' => true,
-                ]);
+            for ($i = 0; $i < $qty; $i++) {
+                $this->cloneProductionOnce($production);
             }
 
             DB::commit();
 
-            return redirect(route('production.index'))->with('success', 'Production duplicated successfully');
+            return redirect(route('production.index'))->with(
+                'success',
+                $qty === 1 ? 'Production duplicated successfully' : "$qty productions duplicated successfully"
+            );
         } catch (\Throwable $th) {
             DB::rollBack();
             report($th);
 
             return back()->with('error', 'Something went wrong. Please contact administrator');
         }
+    }
+
+    private function cloneProductionOnce(Production $production): Production
+    {
+        // Create new production
+        $newProduction = Production::create([
+            'sku' => $this->prod->generateSku(),
+            'product_id' => $production->product_id,
+            'sale_id' => $production->sale_id,
+            'name' => $production->name,
+            'desc' => $production->desc,
+            'remark' => $production->remark,
+            'start_date' => now()->format('Y-m-d'),
+            'due_date' => $production->due_date != null && $production->start_date != null
+                ? now()->addDays(Carbon::parse($production->start_date)->diffInDays(Carbon::parse($production->due_date)))->format('Y-m-d')
+                : null,
+            'status' => Production::STATUS_TO_DO,
+            'type' => $production->type,
+            'priority_id' => $production->priority_id,
+            'factory_id' => $production->factory_id,
+        ]);
+        (new Branch)->assign(Production::class, $newProduction->id);
+
+        // Copy user assignments
+        foreach ($production->users as $user) {
+            UserProduction::create([
+                'user_id' => $user->id,
+                'production_id' => $newProduction->id,
+            ]);
+        }
+
+        // Copy milestones and material previews
+        foreach ($production->milestones as $milestone) {
+            $newProdMs = ProductionMilestone::create([
+                'production_id' => $newProduction->id,
+                'milestone_id' => $milestone->id,
+                'sequence' => $milestone->pivot->sequence ?? 1,
+            ]);
+
+            // Copy material preview records
+            $oldProdMsId = ProductionMilestone::where('production_id', $production->id)
+                ->where('milestone_id', $milestone->id)
+                ->value('id');
+
+            if ($oldProdMsId) {
+                $previews = ProductionMilestoneMaterialPreview::where('production_milestone_id', $oldProdMsId)->get();
+                foreach ($previews as $preview) {
+                    ProductionMilestoneMaterialPreview::create([
+                        'production_milestone_id' => $newProdMs->id,
+                        'product_id' => $preview->product_id,
+                        'qty' => $preview->qty,
+                    ]);
+                }
+            }
+        }
+
+        // Create Raw Material Request
+        if ($production->type != Production::TYPE_RND) {
+            $materialUse = MaterialUse::with('materials')->where('product_id', $production->product_id)->first();
+            if ($materialUse != null) {
+                $rmq = RawMaterialRequest::create([
+                    'production_id' => $newProduction->id,
+                    'material_use_id' => $materialUse->id,
+                    'status' => RawMaterialRequest::STATUS_IN_PROGRESS,
+                    'requested_by' => Auth::user()->id,
+                ]);
+                (new Branch)->assign(RawMaterialRequest::class, $rmq->id);
+
+                $data = [];
+                foreach ($materialUse->materials as $material) {
+                    $data[] = [
+                        'raw_material_request_id' => $rmq->id,
+                        'product_id' => $material->product_id,
+                        'status' => RawMaterialRequestMaterial::MATERIAL_STATUS_IN_PROGRESS,
+                        'qty' => $material->material->is_sparepart ? 1 : $material->qty,
+                        'created_at' => now(),
+                    ];
+                }
+                RawMaterialRequestMaterial::insert($data);
+            }
+
+            // Set product in_production flag
+            Product::where('id', $production->product_id)->update([
+                'in_production' => true,
+            ]);
+        }
+
+        return $newProduction;
     }
 
     public function checkInMilestone(Request $req)

--- a/app/Http/Controllers/VehicleController.php
+++ b/app/Http/Controllers/VehicleController.php
@@ -91,7 +91,13 @@ class VehicleController extends Controller
                 'area_control' => $record->area_control,
                 'status' => $record->status,
                 'sold_date' => $record->sold_date,
-                'type' => $record->type == Vehicle::TYPE_CAR ? 'Car' : 'Lorry',
+                'type' => match ($record->type) {
+                    Vehicle::TYPE_CAR => 'Car',
+                    Vehicle::TYPE_LORRY => 'Lorry',
+                    Vehicle::TYPE_VAN => 'Van',
+                    Vehicle::TYPE_MOTOR => 'Motor',
+                    default => null,
+                },
             ];
         }
 

--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -18,6 +18,8 @@ class Vehicle extends Model
     const STATUS_SOLD = 2;
     const TYPE_CAR = 1;
     const TYPE_LORRY = 2;
+    const TYPE_VAN = 3;
+    const TYPE_MOTOR = 4;
 
     protected $guarded = [];
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,6 +30,7 @@ class DatabaseSeeder extends Seeder
             PrioritySeeder::class,
             StateCitySeeder::class,
             UOMSeeder::class,
+            VehicleSeeder::class,
         ]);
     }
 }

--- a/database/seeders/VehicleSeeder.php
+++ b/database/seeders/VehicleSeeder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Branch;
+use App\Models\Scopes\BranchScope;
+use App\Models\Vehicle;
+use DateTimeInterface;
+use Illuminate\Database\Seeder;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+class VehicleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $filePath = base_path('../VEHICLE LIST.xlsx');
+
+        if (!file_exists($filePath)) {
+            $this->command->error("Excel file not found at: {$filePath}");
+            return;
+        }
+
+        $rows = IOFactory::load($filePath)
+            ->getActiveSheet()
+            ->toArray(null, true, true, false);
+
+        $typeMap = [
+            'CAR'   => Vehicle::TYPE_CAR,
+            'LORRY' => Vehicle::TYPE_LORRY,
+            'VAN'   => Vehicle::TYPE_VAN,
+            'MOTOR' => Vehicle::TYPE_MOTOR,
+        ];
+
+        $branchMap = [
+            'HQ'     => Branch::LOCATION_KL,
+            'PENANG' => Branch::LOCATION_PENANG,
+        ];
+
+        $seeded = 0;
+        $skipped = 0;
+
+        foreach ($rows as $i => $row) {
+            if ($i === 0) continue;
+
+            $plate = trim($row[0] ?? '');
+            if ($plate === '') continue;
+
+            $branchKey = strtoupper(trim($row[12] ?? ''));
+            if (!isset($branchMap[$branchKey])) {
+                $skipped++;
+                continue;
+            }
+
+            $typeKey = strtoupper(trim($row[11] ?? ''));
+            if (!isset($typeMap[$typeKey])) {
+                $skipped++;
+                continue;
+            }
+
+            $tarikh = $row[8] ?? null;
+            if ($tarikh instanceof DateTimeInterface) {
+                $tarikh = $tarikh->format('Y-m-d');
+            } elseif (is_string($tarikh)) {
+                $tarikh = trim($tarikh);
+            }
+
+            $vehicle = Vehicle::withoutGlobalScope(BranchScope::class)->updateOrCreate(
+                ['plate_number' => $plate],
+                [
+                    'chasis'             => trim((string) ($row[1] ?? '')),
+                    'buatan_nama_model'  => trim((string) ($row[2] ?? '')),
+                    'keupayaan_enjin'    => is_null($row[3] ?? null) ? null : (string) $row[3],
+                    'bahan_bakar'        => trim((string) ($row[4] ?? '')),
+                    'status_asal'        => trim((string) ($row[5] ?? '')),
+                    'kelas_kegunaan'     => trim((string) ($row[6] ?? '')),
+                    'jenis_badan'        => trim((string) ($row[7] ?? '')),
+                    'tarikh_pendaftaran' => $tarikh,
+                    'department'         => trim((string) ($row[10] ?? '')),
+                    'type'               => $typeMap[$typeKey],
+                    'status'             => Vehicle::STATUS_ACTIVE,
+                ]
+            );
+
+            $alreadyLinked = Branch::where('object_type', Vehicle::class)
+                ->where('object_id', $vehicle->id)
+                ->exists();
+
+            if (!$alreadyLinked) {
+                Branch::create([
+                    'object_type' => Vehicle::class,
+                    'object_id'   => $vehicle->id,
+                    'location'    => $branchMap[$branchKey],
+                ]);
+            }
+
+            $seeded++;
+        }
+
+        $this->command->info("Vehicles seeded: {$seeded}, skipped: {$skipped}.");
+    }
+}

--- a/resources/views/production/list.blade.php
+++ b/resources/views/production/list.blade.php
@@ -124,13 +124,20 @@
 
     {{-- Duplicate Modal --}}
     <x-app.modal.base-modal id="duplicate-modal">
-        <div class="aspect-[2/1] flex flex-col">
+        <div class="flex flex-col">
             <div class="py-2 px-4 bg-gray-100">
                 <h6 class="text-lg font-black">{{ __('Duplicate Production') }}</h6>
             </div>
             <div class="flex-1 flex flex-col p-4">
-                <div class="flex-1">
-                    <p class="text-slate-500 leading-snug">{{ __('Would you like to edit the duplicated production before creating, or confirm to duplicate immediately?') }}</p>
+                <div class="flex-1 mb-4">
+                    <p class="text-slate-600 leading-snug text-sm">{{ __('Would you like to edit the duplicated production before creating, or confirm to duplicate immediately?') }}</p>
+                </div>
+                <div class="mb-4">
+                    <label for="duplicate-qty" class="block text-sm font-medium text-slate-700 mb-1">{{ __('How many copies?') }}</label>
+                    <input type="number" min="1" max="20" value="1" id="duplicate-qty" name="duplicate-qty"
+                        class="w-full bg-white rounded-md border border-gray-300 p-2 text-sm focus:ring-0" />
+                    <p class="mt-1 text-xs text-slate-500">{{ __('Enter 1 to 20. Edit always opens one copy.') }}</p>
+                    <p class="mt-2 text-sm text-red-600 hidden" id="duplicate-qty-error">&nbsp;</p>
                 </div>
                 <div class="flex gap-x-6">
                     <div class="flex-1">
@@ -485,12 +492,26 @@
 
             $('#duplicate-modal #duplicate-edit-btn').attr('href', `{{ config('app.url') }}/production/create?id=${id}`)
             $('#duplicate-modal #duplicate-confirm-btn').attr('href', `{{ config('app.url') }}/production/quick-duplicate/${id}`)
+            $('#duplicate-qty').val(1)
+            $('#duplicate-qty-error').addClass('hidden').text('')
             $('#duplicate-modal').addClass('show-modal')
         })
         $('#duplicate-modal').on('click', function(e) {
             if ($(e.target).is('#duplicate-modal')) {
                 $('#duplicate-modal').removeClass('show-modal')
             }
+        })
+        $('#duplicate-modal #duplicate-confirm-btn').on('click', function(e) {
+            e.preventDefault()
+            let qty = parseInt($('#duplicate-qty').val(), 10)
+            let $err = $('#duplicate-qty-error')
+            if (!Number.isInteger(qty) || qty < 1 || qty > 20) {
+                $err.removeClass('hidden').text('{{ __('Enter a number between 1 and 20.') }}')
+                return
+            }
+            $err.addClass('hidden').text('')
+            let baseHref = $(this).attr('href')
+            window.location.href = `${baseHref}?qty=${qty}`
         })
 
         $('#data-table').on('click', '.delete-btns', function() {

--- a/resources/views/vehicle/form.blade.php
+++ b/resources/views/vehicle/form.blade.php
@@ -72,6 +72,8 @@
                         <option value="">{{ __('Select a type') }}</option>
                         <option value="1" @selected(old('type', isset($vehicle) ? $vehicle->type : null) == 1)>{{ __('Car') }}</option>
                         <option value="2" @selected(old('type', isset($vehicle) ? $vehicle->type : null) == 2)>{{ __('Lorry') }}</option>
+                        <option value="3" @selected(old('type', isset($vehicle) ? $vehicle->type : null) == 3)>{{ __('Van') }}</option>
+                        <option value="4" @selected(old('type', isset($vehicle) ? $vehicle->type : null) == 4)>{{ __('Motor') }}</option>
                     </x-app.input.select>
                     <x-input-error :messages="$errors->get('type')" class="mt-2" />
                 </div>

--- a/tests/Feature/ProductionQuickDuplicateTest.php
+++ b/tests/Feature/ProductionQuickDuplicateTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Branch;
+use App\Models\Production;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Session;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class ProductionQuickDuplicateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Session::put('as_branch', Branch::LOCATION_KL);
+    }
+
+    private function aProduction(): Production
+    {
+        $p = Production::first();
+        $this->assertNotNull($p, 'Expected at least one Production in the test DB');
+
+        return $p;
+    }
+
+    public function test_qty_default_one_keeps_existing_behaviour(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+        $before = Production::count();
+
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+
+        $response->assertRedirect(route('production.index'));
+        $this->assertSame($before + 1, Production::count(), 'Without qty, should create exactly one copy');
+    }
+
+    public function test_qty_three_creates_three_copies_in_one_transaction(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+        $before = Production::count();
+
+        $response = $this->get(route('production.quick_duplicate', $source->id).'?qty=3');
+
+        $response->assertRedirect(route('production.index'));
+        $this->assertSame($before + 3, Production::count(), 'qty=3 should create three copies');
+    }
+
+    public function test_qty_zero_is_rejected(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+        $before = Production::count();
+
+        $response = $this->get(route('production.quick_duplicate', $source->id).'?qty=0');
+
+        $response->assertStatus(302); // redirect back with validation error
+        $this->assertSame($before, Production::count(), 'qty=0 should not create any copies');
+    }
+
+    public function test_qty_above_max_is_rejected(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+        $before = Production::count();
+
+        $response = $this->get(route('production.quick_duplicate', $source->id).'?qty=21');
+
+        $response->assertStatus(302);
+        $this->assertSame($before, Production::count(), 'qty=21 should not create any copies');
+    }
+
+    public function test_requires_production_create_permission(): void
+    {
+        Permission::firstOrCreate(['name' => 'production.create', 'guard_name' => 'web']);
+        $source = $this->aProduction();
+
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+
+        $response->assertStatus(403);
+    }
+
+    public function test_each_copy_gets_a_unique_sku(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+        $beforeMaxId = (int) Production::max('id');
+
+        $response = $this->get(route('production.quick_duplicate', $source->id).'?qty=4');
+        $response->assertRedirect(route('production.index'));
+
+        $newSkus = Production::where('id', '>', $beforeMaxId)->pluck('sku')->toArray();
+        $this->assertCount(4, $newSkus);
+        $this->assertCount(4, array_unique($newSkus), 'All four duplicated copies must have unique SKUs');
+    }
+}

--- a/tests/Feature/ReimportRawMaterialsCommandTest.php
+++ b/tests/Feature/ReimportRawMaterialsCommandTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Branch;
+use App\Models\InventoryCategory;
+use App\Models\InventoryType;
+use App\Models\Product;
+use App\Models\ProductCost;
+use App\Models\Supplier;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use Tests\TestCase;
+
+class ReimportRawMaterialsCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const COMPANY_GROUP_POWERCOOL = 1;
+
+    /** @var string|null Path to the fixture xlsx written in setUp. */
+    private ?string $fixturePath = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->fixturePath !== null && File::exists($this->fixturePath)) {
+            File::delete($this->fixturePath);
+        }
+        parent::tearDown();
+    }
+
+    public function test_fresh_import_creates_products_with_correct_sparepart_split(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        $beforeType2 = Product::withoutGlobalScopes()->where('type', Product::TYPE_RAW_MATERIAL)->count();
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $afterType2 = Product::withoutGlobalScopes()->where('type', Product::TYPE_RAW_MATERIAL)->count();
+        // Fixture has 10 rows; all existing type=2 were wiped first.
+        $this->assertSame(10, $afterType2, 'Expected 10 raw-material rows after import, before was '.$beforeType2);
+
+        $sparepart = Product::withoutGlobalScopes()
+            ->where('type', Product::TYPE_RAW_MATERIAL)
+            ->where('is_sparepart', true)
+            ->count();
+        $this->assertSame(5, $sparepart, 'Expected 5 spare parts');
+
+        $rawOnly = Product::withoutGlobalScopes()
+            ->where('type', Product::TYPE_RAW_MATERIAL)
+            ->where('is_sparepart', false)
+            ->count();
+        $this->assertSame(5, $rawOnly, 'Expected 5 raw-materials-only');
+    }
+
+    public function test_existing_type2_rows_are_purged_before_insert(): void
+    {
+        $this->ensureSeedReferenceData();
+        $cat = InventoryCategory::withoutGlobalScopes()->where('company_group', self::COMPANY_GROUP_POWERCOOL)->first();
+
+        $stale = Product::create([
+            'inventory_category_id' => $cat->id,
+            'type' => Product::TYPE_RAW_MATERIAL,
+            'sku' => 'STALE-PRE-IMPORT-'.uniqid(),
+            'model_desc' => 'Will be wiped',
+            'is_active' => true,
+            'is_sparepart' => false,
+            'company_group' => self::COMPANY_GROUP_POWERCOOL,
+        ]);
+        (new Branch)->assign(Product::class, $stale->id, Branch::LOCATION_KL);
+
+        $path = $this->writeFixture($this->sampleRows());
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $this->assertNull(
+            Product::withoutGlobalScopes()->find($stale->id),
+            'Stale raw-material row should have been hard-deleted'
+        );
+    }
+
+    public function test_finished_products_are_untouched(): void
+    {
+        $this->ensureSeedReferenceData();
+        $cat = InventoryCategory::withoutGlobalScopes()->where('company_group', self::COMPANY_GROUP_POWERCOOL)->first();
+
+        $fg = Product::create([
+            'inventory_category_id' => $cat->id,
+            'type' => Product::TYPE_PRODUCT,
+            'sku' => 'FG-KEEP-'.uniqid(),
+            'model_desc' => 'Finished good',
+            'is_active' => true,
+            'company_group' => self::COMPANY_GROUP_POWERCOOL,
+        ]);
+        (new Branch)->assign(Product::class, $fg->id, Branch::LOCATION_KL);
+
+        $path = $this->writeFixture($this->sampleRows());
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $this->assertNotNull(
+            Product::withoutGlobalScopes()->find($fg->id),
+            'type=1 finished product must not be deleted'
+        );
+    }
+
+    public function test_supplier_name_is_trimmed_and_deduped(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $byTrimmed = Product::withoutGlobalScopes()->where('sku', 'TEST-SP-MIA-TRIM')->first();
+        $byClean = Product::withoutGlobalScopes()->where('sku', 'TEST-SP-MIA')->first();
+
+        $this->assertNotNull($byTrimmed);
+        $this->assertNotNull($byClean);
+        $this->assertSame(
+            $byTrimmed->supplier_id,
+            $byClean->supplier_id,
+            '"MIA " with trailing space must resolve to the same supplier as "MIA"'
+        );
+        $this->assertNotNull($byTrimmed->supplier_id);
+    }
+
+    public function test_blank_supplier_results_in_null_supplier_id(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $noSupplier = Product::withoutGlobalScopes()->where('sku', 'TEST-RM-NOSUP')->first();
+        $this->assertNotNull($noSupplier, 'Row with blank supplier should still be inserted');
+        $this->assertNull($noSupplier->supplier_id);
+    }
+
+    public function test_missing_category_is_auto_created(): void
+    {
+        $this->ensureSeedReferenceData();
+        $missingName = 'BRAND-NEW-CAT-'.uniqid();
+        $rows = $this->sampleRows();
+        $rows[0]['category'] = $missingName;
+
+        $path = $this->writeFixture($rows);
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $cat = InventoryCategory::withoutGlobalScopes()
+            ->where('name', $missingName)
+            ->where('company_group', self::COMPANY_GROUP_POWERCOOL)
+            ->first();
+
+        $this->assertNotNull($cat, 'New category should have been auto-created');
+    }
+
+    public function test_cost_creates_product_costs_row(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+
+        $prod = Product::withoutGlobalScopes()->where('sku', 'TEST-SP-COST')->first();
+        $this->assertNotNull($prod);
+
+        $cost = ProductCost::where('product_id', $prod->id)->first();
+        $this->assertNotNull($cost, 'Expected a product_costs audit row');
+        $this->assertEquals(12.5, (float) $cost->unit_price);
+    }
+
+    public function test_dry_run_does_not_persist_any_writes(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        $beforeCount = Product::withoutGlobalScopes()
+            ->where('type', Product::TYPE_RAW_MATERIAL)
+            ->count();
+
+        Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--dry-run' => true,
+            '--skip-photos' => true,
+        ]);
+
+        $afterCount = Product::withoutGlobalScopes()
+            ->where('type', Product::TYPE_RAW_MATERIAL)
+            ->count();
+
+        $this->assertSame($beforeCount, $afterCount, 'Dry run must not change DB state');
+    }
+
+    public function test_skip_photos_does_not_invoke_photo_seeder(): void
+    {
+        $this->ensureSeedReferenceData();
+        $path = $this->writeFixture($this->sampleRows());
+
+        $exitCode = Artisan::call('products:reimport-raw-materials', [
+            'path' => $path,
+            '--skip-photos' => true,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringNotContainsString('Spare Part Photo Seeder', $output);
+        $this->assertStringNotContainsString('SparePartPhotoSeeder', $output);
+    }
+
+    // ─────────────────────────── Helpers ───────────────────────────
+
+    /**
+     * Ensure at least one InventoryCategory / Supplier / InventoryType exists
+     * so the command has lookup targets. Scoped to PowerCool (company_group=1).
+     */
+    private function ensureSeedReferenceData(): void
+    {
+        if (InventoryCategory::withoutGlobalScopes()
+            ->where('company_group', self::COMPANY_GROUP_POWERCOOL)
+            ->where('name', 'TEST-CAT')
+            ->doesntExist()
+        ) {
+            $cat = InventoryCategory::create([
+                'name' => 'TEST-CAT',
+                'is_active' => true,
+                'company_group' => self::COMPANY_GROUP_POWERCOOL,
+            ]);
+            foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+                Branch::create([
+                    'object_type' => InventoryCategory::class,
+                    'object_id' => $cat->id,
+                    'location' => $loc,
+                ]);
+            }
+        }
+
+        if (Supplier::withoutGlobalScopes()
+            ->where('name', 'MIA')
+            ->where('company_group', self::COMPANY_GROUP_POWERCOOL)
+            ->doesntExist()
+        ) {
+            $sup = Supplier::create([
+                'name' => 'MIA',
+                'phone' => '000',
+                'is_active' => true,
+                'company_group' => self::COMPANY_GROUP_POWERCOOL,
+            ]);
+            foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+                Branch::create([
+                    'object_type' => Supplier::class,
+                    'object_id' => $sup->id,
+                    'location' => $loc,
+                ]);
+            }
+        }
+
+        if (InventoryType::withoutGlobalScopes()
+            ->where('name', 'MSP')
+            ->where('company_group', self::COMPANY_GROUP_POWERCOOL)
+            ->doesntExist()
+        ) {
+            $it = InventoryType::create([
+                'name' => 'MSP',
+                'is_active' => true,
+                'company_group' => self::COMPANY_GROUP_POWERCOOL,
+                'type' => InventoryType::TYPE_RAW_MATERIAL,
+            ]);
+            foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+                Branch::create([
+                    'object_type' => InventoryType::class,
+                    'object_id' => $it->id,
+                    'location' => $loc,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>> 10 fixture rows: 5 SP + 5 RAW MAT.
+     */
+    private function sampleRows(): array
+    {
+        return [
+            ['sku' => 'TEST-SP-001',       'uom' => 'PCS', 'desc' => 'Spare part 1',  'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 2.70, 'is_sp' => 'SP'],
+            ['sku' => 'TEST-SP-COST',      'uom' => 'PCS', 'desc' => 'Spare part 2',  'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 12.5, 'is_sp' => 'SP'],
+            ['sku' => 'TEST-SP-MIA',       'uom' => 'PCS', 'desc' => 'Spare part 3',  'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 1.00, 'is_sp' => 'SP'],
+            ['sku' => 'TEST-SP-MIA-TRIM',  'uom' => 'PCS', 'desc' => 'Spare part 4',  'category' => 'TEST-CAT', 'supplier' => 'MIA ', 'cost' => 1.00, 'is_sp' => 'SP'],
+            ['sku' => 'TEST-SP-SLASH 1/4', 'uom' => 'PCS', 'desc' => 'Slash SKU',     'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 1.00, 'is_sp' => 'SP'],
+            ['sku' => 'TEST-RM-001',       'uom' => 'SET', 'desc' => 'Raw mat 1',     'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 5.00, 'is_sp' => 'RAW MAT'],
+            ['sku' => 'TEST-RM-002',       'uom' => 'SET', 'desc' => 'Raw mat 2',     'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 5.00, 'is_sp' => 'RAW MAT'],
+            ['sku' => 'TEST-RM-003',       'uom' => 'SET', 'desc' => 'Raw mat 3',     'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 5.00, 'is_sp' => 'RAW MAT'],
+            ['sku' => 'TEST-RM-004',       'uom' => 'SET', 'desc' => 'Raw mat 4',     'category' => 'TEST-CAT', 'supplier' => 'MIA',  'cost' => 5.00, 'is_sp' => 'RAW MAT'],
+            ['sku' => 'TEST-RM-NOSUP',     'uom' => 'SET', 'desc' => 'No supplier',   'category' => 'TEST-CAT', 'supplier' => null,   'cost' => 5.00, 'is_sp' => 'RAW MAT'],
+        ];
+    }
+
+    /**
+     * Write a fixture xlsx that mimics the shape of the real file:
+     * - Rows 1–6 are filler/headers (ignored by the importer).
+     * - Row 7 is the canonical header row.
+     * - Data starts at row 8.
+     *
+     * Columns follow the real file's layout; we only populate the columns
+     * the importer actually reads.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function writeFixture(array $rows): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Sheet1');
+
+        // Header row (row 7 in real file).
+        $headers = [
+            'A' => null,
+            'B' => 'No.',
+            'C' => 'Item Code',
+            'D' => 'UOM',
+            'E' => 'UOM Count',
+            'F' => 'Description',
+            'G' => 'CATEGORY',
+            'H' => 'INVENTORY TYPE',
+            'I' => null,
+            'J' => 'COST',
+            'K' => 'SUPPLIER ID',
+            'M' => 'COMPANY',
+            'AD' => 'ITEM_TYPE',
+            'AH' => 'is_sparepart',
+        ];
+        foreach ($headers as $col => $val) {
+            if ($val !== null) {
+                $sheet->setCellValue($col.'7', $val);
+            }
+        }
+
+        $rowNum = 8;
+        foreach ($rows as $idx => $r) {
+            $sheet->setCellValue('A'.$rowNum, 1);
+            $sheet->setCellValue('B'.$rowNum, $idx + 1);
+            $sheet->setCellValue('C'.$rowNum, $r['sku']);
+            $sheet->setCellValue('D'.$rowNum, $r['uom']);
+            $sheet->setCellValue('E'.$rowNum, 1);
+            $sheet->setCellValue('F'.$rowNum, $r['desc']);
+            $sheet->setCellValue('G'.$rowNum, $r['category']);
+            $sheet->setCellValue('H'.$rowNum, 'RAW MATERIAL');
+            $sheet->setCellValue('I'.$rowNum, $r['supplier']);
+            $sheet->setCellValue('J'.$rowNum, $r['cost']);
+            $sheet->setCellValue('M'.$rowNum, 'PC');
+            $sheet->setCellValue('AD'.$rowNum, 'MSP');
+            $sheet->setCellValue('AH'.$rowNum, $r['is_sp']);
+            $rowNum++;
+        }
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'rm_import_').'.xlsx';
+        (new XlsxWriter($spreadsheet))->save($tmpPath);
+        $this->fixturePath = $tmpPath;
+
+        return $tmpPath;
+    }
+}

--- a/tests/Feature/UpdateProductUomCommandTest.php
+++ b/tests/Feature/UpdateProductUomCommandTest.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Branch;
+use App\Models\InventoryCategory;
+use App\Models\Product;
+use App\Models\UOM;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use Tests\TestCase;
+
+class UpdateProductUomCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const COMPANY_GROUP_HITEN = 2;
+
+    /** @var string[] paths to fixture xlsx files (cleaned up in tearDown) */
+    private array $fixturePaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->fixturePaths as $p) {
+            if (File::exists($p)) {
+                File::delete($p);
+            }
+        }
+        parent::tearDown();
+    }
+
+    public function test_finish_good_phase_realigns_uom_id(): void
+    {
+        [$uomMth, $uomPcs, $uomTrip, $uomUnit] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        $p1 = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-UNIT-001', $uomMth->id, $cat->id);
+        $p2 = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-PCS-001', '7', $cat->id); // dangling
+        $p3 = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-TRIP-001', $uomTrip->id, $cat->id);
+
+        $fg = $this->writeFgFixture([
+            ['sku' => 'FG-UNIT-001', 'uom' => 'UNIT'],
+            ['sku' => 'FG-PCS-001',  'uom' => 'PCS'],
+            ['sku' => 'FG-TRIP-001', 'uom' => 'TRIP'],
+        ]);
+        $rm = $this->writeRmFixture([]); // empty RM file is still a valid xlsx
+
+        $exit = Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame((string) $uomUnit->id, $this->currentUom($p1->id));
+        $this->assertSame((string) $uomPcs->id, $this->currentUom($p2->id));
+        $this->assertSame((string) $uomTrip->id, $this->currentUom($p3->id));
+    }
+
+    public function test_raw_material_phase_writes_uom_id_and_auto_creates_missing(): void
+    {
+        [, $uomPcs] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        // PCS already exists in uom table; ROLL and KG do not — they should be auto-created.
+        $rm1 = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-FOO', 'PCS', $cat->id);   // legacy name-based value
+        $rm2 = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-BAR', (string) $uomPcs->id, $cat->id); // already id, but xlsx says ROLL
+        $rm3 = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-BAZ', 'KG', $cat->id);
+
+        $fg = $this->writeFgFixture([]);
+        $rm = $this->writeRmFixture([
+            ['sku' => 'RM-FOO', 'uom' => 'PCS'],
+            ['sku' => 'RM-BAR', 'uom' => 'ROLL'],
+            ['sku' => 'RM-BAZ', 'uom' => 'KG'],
+        ]);
+
+        $exit = Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--force' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+
+        $rollId = (string) DB::table('uom')->where('name', 'ROLL')->value('id');
+        $kgId = (string) DB::table('uom')->where('name', 'KG')->value('id');
+        $this->assertNotEmpty($rollId, 'ROLL should have been auto-created');
+        $this->assertNotEmpty($kgId, 'KG should have been auto-created');
+
+        $this->assertSame((string) $uomPcs->id, $this->currentUom($rm1->id));
+        $this->assertSame($rollId, $this->currentUom($rm2->id));
+        $this->assertSame($kgId, $this->currentUom($rm3->id));
+
+        // Auto-created UOMs must come with KL + Penang branch morph rows so they appear under BranchScope.
+        foreach (['ROLL', 'KG'] as $name) {
+            $uomId = DB::table('uom')->where('name', $name)->value('id');
+            $branches = DB::table('branches')
+                ->where('object_type', UOM::class)
+                ->where('object_id', $uomId)
+                ->pluck('location')
+                ->all();
+            $this->assertContains(Branch::LOCATION_KL, $branches, "{$name} missing KL branch row");
+            $this->assertContains(Branch::LOCATION_PENANG, $branches, "{$name} missing Penang branch row");
+        }
+    }
+
+    public function test_dry_run_does_not_create_uom_rows(): void
+    {
+        $this->seedUoms();
+        $cat = $this->seedCategory();
+        $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-NEW-001', 'PCS', $cat->id);
+
+        $fg = $this->writeFgFixture([]);
+        $rm = $this->writeRmFixture([
+            ['sku' => 'RM-NEW-001', 'uom' => 'BRANDNEWUOM'],
+        ]);
+
+        Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--dry-run' => true,
+        ]);
+
+        $this->assertNull(
+            DB::table('uom')->where('name', 'BRANDNEWUOM')->value('id'),
+            'Dry run must not create UOM rows'
+        );
+    }
+
+    public function test_unmatched_db_skus_are_left_untouched(): void
+    {
+        [$uomMth] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        $orphanFg = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-NOT-IN-XLSX', $uomMth->id, $cat->id);
+        $matchedFg = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-MATCHED', $uomMth->id, $cat->id);
+
+        $orphanRm = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-NOT-IN-XLSX', 'PCS', $cat->id);
+        $matchedRm = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-MATCHED', 'PCS', $cat->id);
+
+        $fg = $this->writeFgFixture([
+            ['sku' => 'FG-MATCHED', 'uom' => 'UNIT'],
+        ]);
+        $rm = $this->writeRmFixture([
+            ['sku' => 'RM-MATCHED', 'uom' => 'ROLL'],
+        ]);
+
+        Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--force' => true,
+        ]);
+
+        $rollId = (string) DB::table('uom')->where('name', 'ROLL')->value('id');
+
+        $this->assertSame((string) $uomMth->id, $this->currentUom($orphanFg->id));
+        $this->assertNotSame((string) $uomMth->id, $this->currentUom($matchedFg->id));
+        $this->assertSame('PCS', $this->currentUom($orphanRm->id), 'orphan RM keeps its legacy value untouched');
+        $this->assertSame($rollId, $this->currentUom($matchedRm->id));
+    }
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        [$uomMth] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        $fgRow = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-DRY-001', $uomMth->id, $cat->id);
+        $rmRow = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-DRY-001', 'PCS', $cat->id);
+
+        $fg = $this->writeFgFixture([['sku' => 'FG-DRY-001', 'uom' => 'UNIT']]);
+        $rm = $this->writeRmFixture([['sku' => 'RM-DRY-001', 'uom' => 'ROLL']]);
+
+        Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame((string) $uomMth->id, $this->currentUom($fgRow->id));
+        $this->assertSame('PCS', $this->currentUom($rmRow->id));
+    }
+
+    public function test_skip_flags_isolate_phases(): void
+    {
+        [$uomMth] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        $fgRow = $this->seedProduct(Product::TYPE_PRODUCT, 'FG-SKIP-001', $uomMth->id, $cat->id);
+        $rmRow = $this->seedProduct(Product::TYPE_RAW_MATERIAL, 'RM-SKIP-001', 'PCS', $cat->id);
+
+        $fg = $this->writeFgFixture([['sku' => 'FG-SKIP-001', 'uom' => 'UNIT']]);
+        $rm = $this->writeRmFixture([['sku' => 'RM-SKIP-001', 'uom' => 'ROLL']]);
+
+        // Skip RM phase: RM row stays, FG row updates.
+        Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--skip-rm' => true,
+            '--force' => true,
+        ]);
+        $this->assertNotSame((string) $uomMth->id, $this->currentUom($fgRow->id));
+        $this->assertSame('PCS', $this->currentUom($rmRow->id));
+
+        // Now skip FG phase: RM row updates to ROLL's auto-created id.
+        Artisan::call('app:update-product-uom', [
+            '--rm-path' => $rm,
+            '--skip-fg' => true,
+            '--force' => true,
+        ]);
+        $rollId = (string) DB::table('uom')->where('name', 'ROLL')->value('id');
+        $this->assertNotEmpty($rollId);
+        $this->assertSame($rollId, $this->currentUom($rmRow->id));
+    }
+
+    public function test_unknown_fg_xlsx_uom_aborts(): void
+    {
+        $this->seedUoms();
+        $this->seedCategory();
+
+        $fg = $this->writeFgFixture([['sku' => 'FG-WEIRD-001', 'uom' => 'BOX']]); // BOX not in uom table
+        $rm = $this->writeRmFixture([]);
+
+        $exit = Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rm,
+            '--force' => true,
+        ]);
+
+        $this->assertNotSame(0, $exit, 'Command must abort when FG xlsx has an unknown UOM name');
+    }
+
+    public function test_finish_good_phase_does_not_touch_raw_material_rows(): void
+    {
+        [$uomMth] = $this->seedUoms();
+        $cat = $this->seedCategory();
+
+        $rm = Product::create([
+            'inventory_category_id' => $cat->id,
+            'type' => Product::TYPE_RAW_MATERIAL,
+            'sku' => 'FG-UNIT-001', // overlapping SKU with FG xlsx row
+            'model_desc' => 'Raw mat with overlapping SKU',
+            'is_active' => true,
+            'company_group' => self::COMPANY_GROUP_HITEN,
+            'uom' => 'PCS',
+        ]);
+        Branch::create([
+            'object_type' => Product::class,
+            'object_id' => $rm->id,
+            'location' => Branch::LOCATION_KL,
+        ]);
+
+        $fg = $this->writeFgFixture([['sku' => 'FG-UNIT-001', 'uom' => 'UNIT']]);
+        $rmFile = $this->writeRmFixture([]); // RM xlsx empty
+
+        Artisan::call('app:update-product-uom', [
+            '--fg-path' => $fg,
+            '--rm-path' => $rmFile,
+            '--force' => true,
+        ]);
+
+        $this->assertSame('PCS', $this->currentUom($rm->id), 'type=2 row must not be touched by FG phase');
+    }
+
+    // ─────────────────────────── Helpers ───────────────────────────
+
+    /** @return array{0: UOM, 1: UOM, 2: UOM, 3: UOM} [MTH, PCS, TRIP, UNIT] */
+    private function seedUoms(): array
+    {
+        $rows = [];
+        foreach (['MTH', 'PCS', 'TRIP', 'UNIT'] as $name) {
+            $u = UOM::firstOrCreate(['name' => $name], ['is_active' => true]);
+            foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+                Branch::firstOrCreate([
+                    'object_type' => UOM::class,
+                    'object_id' => $u->id,
+                    'location' => $loc,
+                ]);
+            }
+            $rows[] = $u;
+        }
+        return $rows;
+    }
+
+    private function seedCategory(): InventoryCategory
+    {
+        $cat = InventoryCategory::firstOrCreate(
+            ['name' => 'TEST-PROD-CAT', 'company_group' => self::COMPANY_GROUP_HITEN],
+            ['is_active' => true]
+        );
+        foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+            Branch::firstOrCreate([
+                'object_type' => InventoryCategory::class,
+                'object_id' => $cat->id,
+                'location' => $loc,
+            ]);
+        }
+        return $cat;
+    }
+
+    private function seedProduct(int $type, string $sku, int|string $uom, int $categoryId): Product
+    {
+        $p = Product::create([
+            'inventory_category_id' => $categoryId,
+            'type' => $type,
+            'sku' => $sku,
+            'model_desc' => $sku,
+            'is_active' => true,
+            'company_group' => self::COMPANY_GROUP_HITEN,
+            'uom' => (string) $uom,
+        ]);
+        Branch::create([
+            'object_type' => Product::class,
+            'object_id' => $p->id,
+            'location' => Branch::LOCATION_KL,
+        ]);
+        return $p;
+    }
+
+    private function currentUom(int $productId): ?string
+    {
+        $val = DB::table('products')->where('id', $productId)->value('uom');
+        return $val === null ? null : (string) $val;
+    }
+
+    /**
+     * FG xlsx: sheet "MASTER", row 1 header (D=ITEM CODE, L=UOM), data from row 2.
+     *
+     * @param array<int, array{sku: string, uom: string}> $rows
+     */
+    private function writeFgFixture(array $rows): string
+    {
+        $ss = new Spreadsheet();
+        $sh = $ss->getActiveSheet();
+        $sh->setTitle('MASTER');
+        $sh->setCellValue('D1', 'ITEM CODE');
+        $sh->setCellValue('L1', 'UOM');
+        $r = 2;
+        foreach ($rows as $row) {
+            $sh->setCellValue('D'.$r, $row['sku']);
+            $sh->setCellValue('L'.$r, $row['uom']);
+            $r++;
+        }
+        return $this->saveTmp($ss, 'fg_uom_');
+    }
+
+    /**
+     * RM xlsx: sheet "RAW MATERIALS & SPARE PART LIST", rows 1-7 filler/header,
+     * data from row 8 (C=SKU, D=UOM).
+     *
+     * @param array<int, array{sku: string, uom: string}> $rows
+     */
+    private function writeRmFixture(array $rows): string
+    {
+        $ss = new Spreadsheet();
+        $sh = $ss->getActiveSheet();
+        $sh->setTitle('RAW MATERIALS & SPARE PART LIST');
+        $sh->setCellValue('C7', 'SKU');
+        $sh->setCellValue('D7', 'UOM');
+        $r = 8;
+        foreach ($rows as $row) {
+            $sh->setCellValue('C'.$r, $row['sku']);
+            $sh->setCellValue('D'.$r, $row['uom']);
+            $r++;
+        }
+        return $this->saveTmp($ss, 'rm_uom_');
+    }
+
+    private function saveTmp(Spreadsheet $ss, string $prefix): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), $prefix).'.xlsx';
+        (new XlsxWriter($ss))->save($tmp);
+        $this->fixturePaths[] = $tmp;
+        return $tmp;
+    }
+}

--- a/tests/Unit/ProductMergeServiceNormalizationTest.php
+++ b/tests/Unit/ProductMergeServiceNormalizationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ProductMergeService;
+use PHPUnit\Framework\TestCase;
+
+class ProductMergeServiceNormalizationTest extends TestCase
+{
+    public function test_passes_through_plain_sku(): void
+    {
+        $this->assertSame('ACC-K325CZ1', ProductMergeService::normalizeFromPhotoFilename('ACC-K325CZ1'));
+    }
+
+    public function test_reverses_bang_to_slash(): void
+    {
+        // Filename `A.VALVE 1!4` represents SKU `A.VALVE 1/4`.
+        $this->assertSame('A.VALVE 1/4', ProductMergeService::normalizeFromPhotoFilename('A.VALVE 1!4'));
+    }
+
+    public function test_reverses_at_to_asterisk(): void
+    {
+        // Filename `COIL@BTM` represents SKU `COIL*BTM`.
+        $this->assertSame('COIL*BTM', ProductMergeService::normalizeFromPhotoFilename('COIL@BTM'));
+    }
+
+    public function test_reverses_apostrophe_to_double_quote(): void
+    {
+        // Filename `SCR-5'` represents SKU `SCR-5"`.
+        $this->assertSame('SCR-5"', ProductMergeService::normalizeFromPhotoFilename("SCR-5'"));
+    }
+
+    public function test_reverses_multiple_symbols_in_one_name(): void
+    {
+        $this->assertSame('A/B*C"', ProductMergeService::normalizeFromPhotoFilename('A!B@C\''));
+    }
+
+    public function test_trims_whitespace(): void
+    {
+        $this->assertSame('SKU', ProductMergeService::normalizeFromPhotoFilename('  SKU  '));
+    }
+
+    public function test_leaves_unknown_special_chars_intact(): void
+    {
+        $this->assertSame('COIL-100-3-900', ProductMergeService::normalizeFromPhotoFilename('COIL-100-3-900'));
+    }
+}


### PR DESCRIPTION
…test coverage

- Allow quickDuplicate to accept an optional `qty` param (1–20) so multiple production copies can be created in a single transaction; extract cloneProductionOnce() private method for reuse
- Add qty input field and client-side validation to the Duplicate modal on the production list view
- Add Vehicle TYPE_VAN (3) and TYPE_MOTOR (4) constants; extend getData() match expression and vehicle form select accordingly
- Add VehicleSeeder that imports from VEHICLE LIST.xlsx via PhpSpreadsheet, mapping type/branch columns with updateOrCreate
- Register VehicleSeeder in DatabaseSeeder
- Add ProductionQuickDuplicateTest covering default qty=1, bulk qty=3, boundary rejections (0/21), permission gate, and unique-SKU assertion across four copies
- Add ReimportRawMaterialsCommandTest (8 cases) covering sparepart split, stale-row purge, dry-run, supplier trim/dedup, missing category auto-create, cost row creation, and photo-skip flag
- Add UpdateProductUomCommandTest (8 cases) covering FG/RM phase isolation, dry-run guard, auto-create + branch assignment of unknown UOMs, orphan-row preservation, and unknown-UOM abort
- Add ProductMergeServiceNormalizationTest (7 unit cases) verifying filename-to-SKU symbol reversal (!->/, @->*, '->") and whitespace trim