### PR TITLE
feat(product,production,seeder): import/renumber commands, photo over…

### DIFF
--- a/app/Console/Commands/ImportRawMaterials.php
+++ b/app/Console/Commands/ImportRawMaterials.php
@@ -1,0 +1,634 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Attachment;
+use App\Models\Branch;
+use App\Models\InventoryCategory;
+use App\Models\InventoryType;
+use App\Models\Product;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+class ImportRawMaterials extends Command
+{
+    protected $signature = 'app:import-raw-materials
+        {path? : Absolute path to the RAW MATERIALS & SPARE PART LIST.xlsx file}
+        {--dry-run : Parse and report what would change, without touching the DB or files}
+        {--force : Skip the YES confirmation prompt}';
+
+    protected $description = 'Hard-delete all current raw-material products (with their branch morph rows and related data) and re-import from the Excel file.';
+
+    private const DEFAULT_PATH = '/Users/yapyixian/Herd/powercool/RAW MATERIALS & SPARE PART LIST.xlsx';
+
+    /**
+     * Transactional tables that hold FKs to products.id and must be wiped
+     * before a raw-material product can be hard-deleted.
+     * Value = closure that returns affected-row count for a given $ids array.
+     */
+    private array $existingIds = [];
+
+    public function handle(): int
+    {
+        $path = $this->argument('path') ?? self::DEFAULT_PATH;
+
+        if (! File::exists($path)) {
+            $this->error("File not found: {$path}");
+            return 1;
+        }
+
+        $this->info("Reading: {$path}");
+        $rows = $this->parseExcel($path);
+        $this->info('Parsed ' . count($rows) . ' data rows from Sheet1.');
+
+        [$catLookup, $typeLookup, $supplierLookup] = $this->buildLookups();
+
+        [$resolved, $unmatchedCats, $unmatchedTypes, $skipped] =
+            $this->resolveRows($rows, $catLookup, $typeLookup, $supplierLookup);
+
+        $this->reportResolution($resolved, $unmatchedCats, $unmatchedTypes, $skipped);
+
+        if (count($unmatchedCats) > 0) {
+            $this->error('Aborting: unknown inventory categories — seed InventoryCategorySeeder or fix the sheet.');
+            return 1;
+        }
+
+        $this->existingIds = DB::table('products')
+            ->where('type', Product::TYPE_RAW_MATERIAL)
+            ->pluck('id')
+            ->all();
+
+        $deletePreview = $this->previewDeletes($this->existingIds);
+        $this->reportDeletePreview($deletePreview, count($this->existingIds));
+
+        if ($this->option('dry-run')) {
+            $this->warn('DRY RUN — no changes were made.');
+            return 0;
+        }
+
+        if (! $this->option('force')) {
+            if ($this->ask('Type YES to hard-delete the above and import the new rows') !== 'YES') {
+                $this->info('Aborted.');
+                return 0;
+            }
+        }
+
+        try {
+            DB::beginTransaction();
+            Schema::disableForeignKeyConstraints();
+
+            $this->hardDeleteExisting($this->existingIds);
+            $this->insertRows($resolved);
+
+            Schema::enableForeignKeyConstraints();
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            Schema::enableForeignKeyConstraints();
+            $this->error('Import failed: ' . $e->getMessage());
+            $this->line($e->getTraceAsString());
+            return 1;
+        }
+
+        $this->resetAutoIncrement(['products', 'branches']);
+
+        $this->newLine();
+        $this->info('Import complete. Re-seed photos with:');
+        $this->line('  php artisan db:seed --class=SparePartPhotoSeeder');
+
+        return 0;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Phase 1 — Parse & resolve
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function parseExcel(string $path): array
+    {
+        $reader = IOFactory::createReaderForFile($path);
+        $reader->setReadDataOnly(true);
+        $reader->setLoadSheetsOnly(['RAW MATERIALS & SPARE PART LIST']);
+        $ss = $reader->load($path);
+        $sheet = $ss->getSheetByName('RAW MATERIALS & SPARE PART LIST');
+
+        $rows = [];
+        $last = $sheet->getHighestRow();
+
+        // Data rows start at row 8; row 1 carries DB-compatible column identifiers.
+        for ($r = 8; $r <= $last; $r++) {
+            $get = fn (string $col) => $sheet->getCell($col . $r)->getCalculatedValue();
+
+            $sku = trim((string) $get('C'));
+            if ($sku === '') {
+                continue; // skip blank rows
+            }
+
+            $rows[] = [
+                'row' => $r,
+                'sku' => $sku,
+                'uom' => $this->strOrNull($get('D')),
+                'model_desc' => $this->strOrNull($get('F')),
+                'category_name' => trim((string) $get('G')),
+                'supplier_code' => $this->strOrNull($get('K')),
+                'company_group' => $this->strOrNull($get('M')),
+                'initial_for_production' => $this->strOrNull($get('O')),
+                'qty' => $this->intOrNull($get('Q')),
+                'low_stock_threshold' => $this->intOrNull($get('R')),
+                'min_price' => $this->numOrNull($get('S')),
+                'max_price' => $this->numOrNull($get('T')),
+                'cost' => $this->numOrNull($get('J')),
+                'weight' => $this->numOrNull($get('U')),
+                'length' => $this->numOrNull($get('V')),
+                'width' => $this->numOrNull($get('W')),
+                'height' => $this->numOrNull($get('X')),
+                'capacity' => $this->strOrNull($get('Y')),
+                'refrigerant' => $this->strOrNull($get('Z')),
+                'power_input' => $this->strOrNull($get('AA')),
+                'voltage_frequency' => $this->strOrNull($get('AB')),
+                'standard_features' => $this->strOrNull($get('AC')),
+                'sst' => $this->boolish($get('AE')),
+                'hi_ten_stock_code' => $this->strOrNull($get('AF')),
+                'item_type_name' => trim((string) $get('AH')), // AH = "SP" or "RAW MAT"
+                'lazada_sku' => $this->strOrNull($get('AI')),
+                'shopee_sku' => $this->strOrNull($get('AJ')),
+                'tiktok_sku' => $this->strOrNull($get('AK')),
+                'woo_commerce_sku' => $this->strOrNull($get('AL')),
+            ];
+        }
+
+        return $rows;
+    }
+
+    private function buildLookups(): array
+    {
+        // Inventory categories — resolved across all branches so a raw-material
+        // product is always assigned a category that exists in both KL and
+        // Penang. Preference order per name:
+        //   1. Has branch rows for BOTH KL + Penang
+        //   2. company_group = 1 (PC) over company_group = 2
+        //   3. Lowest id (tie-break)
+        $catRows = DB::table('inventory_categories')
+            ->whereNull('deleted_at')
+            ->get(['id', 'name', 'company_group']);
+
+        $klCatIds = DB::table('branches')
+            ->where('object_type', 'App\\Models\\InventoryCategory')
+            ->where('location', Branch::LOCATION_KL)
+            ->pluck('object_id')
+            ->flip();
+
+        $penangCatIds = DB::table('branches')
+            ->where('object_type', 'App\\Models\\InventoryCategory')
+            ->where('location', Branch::LOCATION_PENANG)
+            ->pluck('object_id')
+            ->flip();
+
+        $catLookup = [];
+        foreach ($catRows->groupBy(fn ($r) => mb_strtoupper(trim($r->name))) as $name => $group) {
+            $scored = $group->map(function ($c) use ($klCatIds, $penangCatIds) {
+                $hasBoth = isset($klCatIds[$c->id]) && isset($penangCatIds[$c->id]);
+                $isPc = (int) $c->company_group === 1;
+                return [
+                    'id' => $c->id,
+                    // sort key: (both-branches desc, pc-first desc, id asc)
+                    'sort' => sprintf('%d-%d-%010d', $hasBoth ? 0 : 1, $isPc ? 0 : 1, $c->id),
+                ];
+            })->sortBy('sort')->values();
+            $catLookup[$name] = $scored->first()['id'];
+        }
+
+        // Inventory types — pick the LOCATION_KL variant (first by id) for the FK.
+        $typeLookup = [];
+        $types = DB::table('inventory_types')
+            ->whereNull('deleted_at')
+            ->orderBy('id')
+            ->get(['id', 'name']);
+        foreach ($types as $t) {
+            $key = mb_strtoupper(trim($t->name));
+            if (! isset($typeLookup[$key])) {
+                $typeLookup[$key] = $t->id;
+            }
+        }
+
+        // Suppliers — by sku code (pick first if duplicates).
+        $supplierLookup = [];
+        $suppliers = DB::table('suppliers')
+            ->whereNull('deleted_at')
+            ->whereNotNull('sku')
+            ->orderBy('id')
+            ->get(['id', 'sku']);
+        foreach ($suppliers as $s) {
+            $key = mb_strtoupper(trim($s->sku));
+            if (! isset($supplierLookup[$key])) {
+                $supplierLookup[$key] = $s->id;
+            }
+        }
+
+        return [$catLookup, $typeLookup, $supplierLookup];
+    }
+
+    private function resolveRows(array $rows, array $catLookup, array $typeLookup, array $supplierLookup): array
+    {
+        $resolved = [];
+        $unmatchedCats = [];
+        $unmatchedTypes = [];
+        $skipped = [];
+
+        foreach ($rows as $row) {
+            $catKey = mb_strtoupper($row['category_name']);
+            if (! isset($catLookup[$catKey])) {
+                $unmatchedCats[$row['category_name']] = ($unmatchedCats[$row['category_name']] ?? 0) + 1;
+                $skipped[] = $row;
+                continue;
+            }
+
+            $typeKey = mb_strtoupper($row['item_type_name']);
+            $itemTypeId = $typeLookup[$typeKey] ?? null;
+            if ($row['item_type_name'] !== '' && $itemTypeId === null) {
+                $unmatchedTypes[$row['item_type_name']] = ($unmatchedTypes[$row['item_type_name']] ?? 0) + 1;
+            }
+
+            $supplierId = null;
+            if ($row['supplier_code'] !== null) {
+                $supplierId = $supplierLookup[mb_strtoupper($row['supplier_code'])] ?? null;
+            }
+
+            // is_sparepart: "SP" → true, "RAW MAT" → false, blank → null
+            $isSparepart = match (mb_strtoupper($row['item_type_name'])) {
+                'SP' => 1,
+                'RAW MAT' => 0,
+                default => null,
+            };
+
+            $resolved[] = $row + [
+                'inventory_category_id' => $catLookup[$catKey],
+                'item_type_id' => $itemTypeId,
+                'resolved_supplier_id' => $supplierId,
+                'is_sparepart' => $isSparepart,
+            ];
+        }
+
+        return [$resolved, $unmatchedCats, $unmatchedTypes, $skipped];
+    }
+
+    private function reportResolution(array $resolved, array $unmatchedCats, array $unmatchedTypes, array $skipped): void
+    {
+        $sp = 0;
+        $rm = 0;
+        $noFlag = 0;
+        foreach ($resolved as $r) {
+            match ($r['is_sparepart']) {
+                1 => $sp++,
+                0 => $rm++,
+                default => $noFlag++,
+            };
+        }
+
+        $this->newLine();
+        $this->info('Import preview:');
+        $this->line("  Would import: " . count($resolved) . " products  (sparepart={$sp}, raw-material={$rm}, unflagged={$noFlag})");
+        $this->line('  Unmatched categories: ' . count($unmatchedCats) . ' (' . array_sum($unmatchedCats) . ' rows)');
+        foreach ($unmatchedCats as $name => $n) {
+            $this->line("    - {$name}: {$n}");
+        }
+        $this->line('  Unmatched item types: ' . count($unmatchedTypes) . ' (' . array_sum($unmatchedTypes) . ' rows)');
+        foreach ($unmatchedTypes as $name => $n) {
+            $this->line("    - {$name}: {$n}");
+        }
+        $this->line('  Skipped rows (category miss): ' . count($skipped));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Phase 2 — Hard-delete preview + execution
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Return [tableOrFolder => rowCount] for each thing we'd delete.
+     */
+    private function previewDeletes(array $ids): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $out = [];
+        $productMorph = 'App\\Models\\Product';
+
+        // Transactional refs (FK-blocking) — force-delete path.
+        $saleProductIds = Schema::hasTable('sale_products')
+            ? DB::table('sale_products')->whereIn('product_id', $ids)->pluck('id')->all()
+            : [];
+
+        if (Schema::hasTable('sale_product_children') && ! empty($saleProductIds)) {
+            $out['sale_product_children'] = DB::table('sale_product_children')->whereIn('sale_product_id', $saleProductIds)->count();
+        }
+        if (Schema::hasTable('delivery_order_products') && ! empty($saleProductIds)) {
+            $out['delivery_order_products'] = DB::table('delivery_order_products')->whereIn('sale_product_id', $saleProductIds)->count();
+        }
+        if (Schema::hasTable('sale_products')) {
+            $out['sale_products'] = count($saleProductIds);
+        }
+        $this->addDeleteCount($out, 'production_milestone_materials', 'product_id', $ids);
+        $this->addDeleteCount($out, 'production_milestone_materials_preview', 'product_id', $ids);
+        $this->addMorphDeleteCount($out, 'task_milestone_inventories', 'inventory_type', 'inventory_id', $productMorph, $ids);
+        $this->addDeleteCount($out, 'material_use_products', 'product_id', $ids);
+        $this->addDeleteCount($out, 'grn', 'product_id', $ids);
+        $this->addDeleteCount($out, 'promotions', 'product_id', $ids);
+        $this->addMorphDeleteCount($out, 'inventory_service_reminders', 'object_type', 'object_id', $productMorph, $ids);
+
+        // Cascade children.
+        $this->addMorphDeleteCount($out, 'attachments', 'object_type', 'object_id', $productMorph, $ids);
+        $out['attachments (files on disk)'] = $this->countProductAttachmentFiles($ids);
+
+        $this->addDeleteCount($out, 'product_children', 'product_id', $ids);
+        $this->addDeleteCount($out, 'product_costs', 'product_id', $ids);
+        $this->addDeleteCount($out, 'product_selling_prices', 'product_id', $ids);
+        $this->addDeleteCount($out, 'product_milestones', 'product_id', $ids);
+        $this->addDeleteCount($out, 'classification_code_product', 'product_id', $ids);
+
+        if (Schema::hasTable('factory_raw_materials')) {
+            $frmIds = DB::table('factory_raw_materials')->whereIn('product_id', $ids)->pluck('id')->all();
+            if (Schema::hasTable('factory_raw_material_records')) {
+                $out['factory_raw_material_records'] = empty($frmIds)
+                    ? 0
+                    : DB::table('factory_raw_material_records')->whereIn('factory_raw_material_id', $frmIds)->count();
+            }
+            $out['factory_raw_materials'] = count($frmIds);
+        }
+
+        $this->addMorphDeleteCount($out, 'branches', 'object_type', 'object_id', $productMorph, $ids);
+
+        $out['products (raw material, type=2)'] = count($ids);
+
+        return $out;
+    }
+
+    private function addDeleteCount(array &$out, string $table, string $fk, array $ids): void
+    {
+        if (Schema::hasTable($table)) {
+            $out[$table] = DB::table($table)->whereIn($fk, $ids)->count();
+        }
+    }
+
+    private function addMorphDeleteCount(array &$out, string $table, string $typeCol, string $idCol, string $morph, array $ids): void
+    {
+        if (Schema::hasTable($table)) {
+            $out[$table] = DB::table($table)->where($typeCol, $morph)->whereIn($idCol, $ids)->count();
+        }
+    }
+
+    private function countProductAttachmentFiles(array $ids): int
+    {
+        if (! Schema::hasTable('attachments') || empty($ids)) {
+            return 0;
+        }
+
+        $dir = storage_path('app/' . Attachment::PRODUCT_PATH);
+        if (! File::isDirectory($dir)) {
+            return 0;
+        }
+
+        $srcs = DB::table('attachments')
+            ->where('object_type', 'App\\Models\\Product')
+            ->whereIn('object_id', $ids)
+            ->pluck('src');
+
+        $count = 0;
+        foreach ($srcs as $src) {
+            if ($src && File::exists($dir . '/' . $src)) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    private function reportDeletePreview(array $preview, int $productCount): void
+    {
+        $this->newLine();
+        $this->info("Would hard-delete {$productCount} existing raw-material products plus:");
+        foreach ($preview as $table => $n) {
+            $this->line(sprintf('  - %-45s %d', $table, $n));
+        }
+    }
+
+    private function hardDeleteExisting(array $ids): void
+    {
+        if (empty($ids)) {
+            $this->info('No existing raw materials to delete.');
+            return;
+        }
+
+        $productMorph = 'App\\Models\\Product';
+
+        // Transactional refs first (order: children → parent).
+        $saleProductIds = Schema::hasTable('sale_products')
+            ? DB::table('sale_products')->whereIn('product_id', $ids)->pluck('id')->all()
+            : [];
+
+        if (! empty($saleProductIds)) {
+            if (Schema::hasTable('sale_product_children')) {
+                $this->deleteAndLog('sale_product_children', fn () => DB::table('sale_product_children')->whereIn('sale_product_id', $saleProductIds)->delete());
+            }
+            if (Schema::hasTable('delivery_order_products')) {
+                $this->deleteAndLog('delivery_order_products', fn () => DB::table('delivery_order_products')->whereIn('sale_product_id', $saleProductIds)->delete());
+            }
+        }
+        if (Schema::hasTable('sale_products')) {
+            $this->deleteAndLog('sale_products', fn () => DB::table('sale_products')->whereIn('product_id', $ids)->delete());
+        }
+
+        foreach (['production_milestone_materials', 'production_milestone_materials_preview', 'material_use_products', 'grn', 'promotions'] as $t) {
+            if (Schema::hasTable($t)) {
+                $this->deleteAndLog($t, fn () => DB::table($t)->whereIn('product_id', $ids)->delete());
+            }
+        }
+
+        if (Schema::hasTable('task_milestone_inventories')) {
+            $this->deleteAndLog('task_milestone_inventories', fn () => DB::table('task_milestone_inventories')
+                ->where('inventory_type', $productMorph)
+                ->whereIn('inventory_id', $ids)
+                ->delete());
+        }
+
+        if (Schema::hasTable('inventory_service_reminders')) {
+            $this->deleteAndLog('inventory_service_reminders', fn () => DB::table('inventory_service_reminders')
+                ->where('object_type', $productMorph)
+                ->whereIn('object_id', $ids)
+                ->delete());
+        }
+
+        // Attachment files on disk first, then rows.
+        $this->deleteAttachmentFiles($ids);
+        $this->deleteAndLog('attachments', fn () => DB::table('attachments')
+            ->where('object_type', $productMorph)
+            ->whereIn('object_id', $ids)
+            ->delete());
+
+        foreach (['product_children', 'product_costs', 'product_selling_prices', 'product_milestones', 'classification_code_product'] as $t) {
+            if (Schema::hasTable($t)) {
+                $this->deleteAndLog($t, fn () => DB::table($t)->whereIn('product_id', $ids)->delete());
+            }
+        }
+
+        if (Schema::hasTable('factory_raw_materials')) {
+            $frmIds = DB::table('factory_raw_materials')->whereIn('product_id', $ids)->pluck('id')->all();
+            if (! empty($frmIds) && Schema::hasTable('factory_raw_material_records')) {
+                $this->deleteAndLog('factory_raw_material_records', fn () => DB::table('factory_raw_material_records')->whereIn('factory_raw_material_id', $frmIds)->delete());
+            }
+            $this->deleteAndLog('factory_raw_materials', fn () => DB::table('factory_raw_materials')->whereIn('product_id', $ids)->delete());
+        }
+
+        // The "(with branch)" step.
+        $this->deleteAndLog('branches (morph)', fn () => DB::table('branches')
+            ->where('object_type', $productMorph)
+            ->whereIn('object_id', $ids)
+            ->delete());
+
+        // Finally, the products themselves — use DB::table to bypass SoftDeletes.
+        $this->deleteAndLog('products', fn () => DB::table('products')->whereIn('id', $ids)->delete());
+    }
+
+    private function deleteAndLog(string $label, \Closure $run): void
+    {
+        $n = $run();
+        $this->line(sprintf('  ✓ %-45s %d deleted', $label, $n));
+    }
+
+    private function deleteAttachmentFiles(array $ids): void
+    {
+        $dir = storage_path('app/' . Attachment::PRODUCT_PATH);
+        if (! File::isDirectory($dir)) {
+            return;
+        }
+
+        $srcs = DB::table('attachments')
+            ->where('object_type', 'App\\Models\\Product')
+            ->whereIn('object_id', $ids)
+            ->pluck('src');
+
+        $deleted = 0;
+        foreach ($srcs as $src) {
+            $full = $dir . '/' . $src;
+            if ($src && File::exists($full)) {
+                File::delete($full);
+                $deleted++;
+            }
+        }
+        $this->line("  ✓ attachment files on disk                      {$deleted} deleted");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Phase 3 — Insert rows + branch morphs
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function insertRows(array $resolved): void
+    {
+        $now = now();
+        $bar = $this->output->createProgressBar(count($resolved));
+        $bar->start();
+
+        $created = 0;
+        foreach ($resolved as $r) {
+            $productId = DB::table('products')->insertGetId([
+                'inventory_category_id' => $r['inventory_category_id'],
+                'supplier_id' => $r['resolved_supplier_id'],
+                'type' => Product::TYPE_RAW_MATERIAL,
+                'sku' => $r['sku'],
+                'model_desc' => $r['model_desc'] ?? $r['sku'],
+                'qty' => $r['qty'],
+                'low_stock_threshold' => $r['low_stock_threshold'],
+                'min_price' => $r['min_price'],
+                'max_price' => $r['max_price'],
+                'cost' => $r['cost'] ?? 0,
+                'weight' => $r['weight'],
+                'length' => $r['length'],
+                'width' => $r['width'],
+                'height' => $r['height'],
+                'capacity' => $r['capacity'],
+                'refrigerant' => $r['refrigerant'],
+                'power_input' => $r['power_input'],
+                'voltage_frequency' => $r['voltage_frequency'],
+                'standard_features' => $r['standard_features'],
+                'is_active' => 1,
+                'is_sparepart' => $r['is_sparepart'],
+                'item_type' => $r['item_type_id'],
+                'uom' => $r['uom'],
+                'company_group' => $r['company_group'] ?? 'PC',
+                'initial_for_production' => $r['initial_for_production'],
+                'hi_ten_stock_code' => $r['hi_ten_stock_code'],
+                'lazada_sku' => $r['lazada_sku'],
+                'shopee_sku' => $r['shopee_sku'],
+                'tiktok_sku' => $r['tiktok_sku'],
+                'woo_commerce_sku' => $r['woo_commerce_sku'],
+                'sst' => $r['sst'] ? 1 : 0,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+                DB::table('branches')->insert([
+                    'object_type' => 'App\\Models\\Product',
+                    'object_id' => $productId,
+                    'location' => $loc,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+            $created++;
+            $bar->advance();
+        }
+        $bar->finish();
+        $this->newLine();
+        $this->info("Inserted {$created} products with both KL + Penang branch rows.");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Utilities
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function resetAutoIncrement(array $tables): void
+    {
+        foreach ($tables as $t) {
+            if (! Schema::hasTable($t)) {
+                continue;
+            }
+            try {
+                $maxId = (int) DB::table($t)->max('id');
+                DB::statement("ALTER TABLE `{$t}` AUTO_INCREMENT = " . ($maxId + 1));
+            } catch (\Throwable) {
+                // best-effort; skip silently
+            }
+        }
+    }
+
+    private function strOrNull($v): ?string
+    {
+        if ($v === null) return null;
+        $s = trim((string) $v);
+        return $s === '' ? null : $s;
+    }
+
+    private function numOrNull($v): ?float
+    {
+        if ($v === null || $v === '') return null;
+        if (is_numeric($v)) return (float) $v;
+        return null;
+    }
+
+    private function intOrNull($v): ?int
+    {
+        if ($v === null || $v === '') return null;
+        if (is_numeric($v)) return (int) $v;
+        return null;
+    }
+
+    private function boolish($v): bool
+    {
+        if ($v === null) return false;
+        $s = mb_strtoupper(trim((string) $v));
+        return in_array($s, ['Y', 'YES', '1', 'TRUE'], true);
+    }
+}

--- a/app/Console/Commands/RenumberProducts.php
+++ b/app/Console/Commands/RenumberProducts.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class RenumberProducts extends Command
+{
+    protected $signature = 'app:renumber-products
+        {--dry-run : Print the renumber preview without touching the DB}
+        {--force : Skip the YES confirmation prompt}';
+
+    protected $description = 'Hard-delete trashed products/attachments, then renumber products.id (FG 1..N, RM N+1..M) and attachments.id (1..K) contiguously, propagating to every FK and morph.';
+
+    private const OFFSET = 10_000_000;
+    private const PRODUCT_MORPH = 'App\\Models\\Product';
+
+    /**
+     * Tables with a direct `product_id` FK to products.id.
+     * Filtered by Schema::hasTable() at runtime.
+     */
+    private const PRODUCT_ID_TABLES = [
+        'product_children',
+        'product_costs',
+        'product_selling_prices',
+        'product_milestones',
+        'classification_code_product',
+        'factory_raw_materials',
+        'material_uses',
+        'material_use_products',
+        'production_milestone_materials',
+        'production_milestone_materials_preview',
+        'promotions',
+        'grn',
+        'sale_products',
+        'productions',
+        'service_forms',
+        'service_form_products',
+        'service_form_service_items',
+    ];
+
+    /**
+     * Polymorphic tables that may carry App\Models\Product rows.
+     * Format: [table, type_column, id_column].
+     */
+    private const PRODUCT_MORPH_TABLES = [
+        ['attachments', 'object_type', 'object_id'],
+        ['branches', 'object_type', 'object_id'],
+        ['inventory_service_reminders', 'object_type', 'object_id'],
+        ['task_milestone_inventories', 'inventory_type', 'inventory_id'],
+    ];
+
+    public function handle(): int
+    {
+        if (app()->environment('production')) {
+            $this->error('This command is disabled in production.');
+            return 1;
+        }
+
+        $preview = $this->buildPreview();
+        $this->printPreview($preview);
+
+        if ($this->option('dry-run')) {
+            $this->warn('DRY RUN — no changes were made.');
+            return 0;
+        }
+
+        if (! $this->option('force')) {
+            if ($this->ask('Type YES to execute the renumber') !== 'YES') {
+                $this->info('Aborted.');
+                return 0;
+            }
+        }
+
+        try {
+            DB::beginTransaction();
+            Schema::disableForeignKeyConstraints();
+
+            $this->purgeTrashed();
+            $this->renumberProducts();
+            $this->renumberAttachments();
+
+            Schema::enableForeignKeyConstraints();
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            Schema::enableForeignKeyConstraints();
+            $this->error('Renumber failed: ' . $e->getMessage());
+            $this->line($e->getTraceAsString());
+            return 1;
+        }
+
+        $this->resetAutoIncrements();
+        $this->printSummary();
+
+        return 0;
+    }
+
+    // ─── Preview ──────────────────────────────────────────────────────
+
+    private function buildPreview(): array
+    {
+        $trashedProducts = DB::table('products')->whereNotNull('deleted_at')->count();
+        $trashedAttachments = DB::table('attachments')->whereNotNull('deleted_at')->count();
+
+        $liveProducts = DB::table('products')->whereNull('deleted_at')->count();
+        $fgCount = DB::table('products')->whereNull('deleted_at')->where('type', 1)->count();
+        $rmCount = DB::table('products')->whereNull('deleted_at')->where('type', 2)->count();
+
+        $fkCounts = [];
+        foreach (self::PRODUCT_ID_TABLES as $t) {
+            if (Schema::hasTable($t)) {
+                $fkCounts[$t] = DB::table($t)->whereNotNull('product_id')->count();
+            }
+        }
+        foreach (self::PRODUCT_MORPH_TABLES as [$t, $typeCol, $idCol]) {
+            if (Schema::hasTable($t)) {
+                $fkCounts[$t . " ({$idCol})"] = DB::table($t)->where($typeCol, self::PRODUCT_MORPH)->count();
+            }
+        }
+
+        // products.hi_ten_stock_code self-FK
+        $fkCounts['products (hi_ten_stock_code)'] = DB::table('products')->whereNotNull('hi_ten_stock_code')->count();
+
+        // sale_enquiries.product_service_interested
+        if (Schema::hasTable('sale_enquiries')) {
+            $fkCounts['sale_enquiries (product_service_interested)'] =
+                DB::table('sale_enquiries')->whereNotNull('product_service_interested')->count();
+        }
+
+        return [
+            'trashedProducts' => $trashedProducts,
+            'trashedAttachments' => $trashedAttachments,
+            'liveProducts' => $liveProducts,
+            'fgCount' => $fgCount,
+            'rmCount' => $rmCount,
+            'fkCounts' => $fkCounts,
+        ];
+    }
+
+    private function printPreview(array $p): void
+    {
+        $this->info('Renumber preview');
+        $this->line("  Trashed to purge: products={$p['trashedProducts']}, attachments={$p['trashedAttachments']}");
+        $this->line("  Products to renumber: {$p['liveProducts']}  (FG={$p['fgCount']}, RM={$p['rmCount']})");
+        $this->line("    → new ids 1..{$p['liveProducts']} (FG 1..{$p['fgCount']}, RM " . ($p['fgCount'] + 1) . ".." . $p['liveProducts'] . ")");
+
+        $attLive = DB::table('attachments')->whereNull('deleted_at')->count();
+        $this->line("  Attachments to renumber: {$attLive} (after purge) → new ids 1..{$attLive}");
+
+        $this->line('  FK tables that will be updated:');
+        foreach ($p['fkCounts'] as $label => $n) {
+            $this->line(sprintf('    - %-55s %d', $label, $n));
+        }
+        $this->newLine();
+    }
+
+    // ─── Phase 0: purge trashed ───────────────────────────────────────
+
+    private function purgeTrashed(): void
+    {
+        // 0a — trashed products. Today this is 0, but handle defensively.
+        $trashedProductIds = DB::table('products')->whereNotNull('deleted_at')->pluck('id')->all();
+
+        if (! empty($trashedProductIds)) {
+            $this->info('0a. Hard-deleting trashed products (' . count($trashedProductIds) . ')');
+            $this->cascadeDeleteProductIds($trashedProductIds);
+            $this->deleteAndLog('products (trashed)', fn () => DB::table('products')
+                ->whereIn('id', $trashedProductIds)->delete());
+        } else {
+            $this->line('0a. No trashed products to purge.');
+        }
+
+        // 0b — trashed attachments (leaf).
+        $trashedAttCount = DB::table('attachments')->whereNotNull('deleted_at')->count();
+        if ($trashedAttCount > 0) {
+            $this->info("0b. Hard-deleting trashed attachments ({$trashedAttCount})");
+            $this->deleteAndLog('attachments (trashed)', fn () => DB::table('attachments')
+                ->whereNotNull('deleted_at')->delete());
+        } else {
+            $this->line('0b. No trashed attachments to purge.');
+        }
+    }
+
+    private function cascadeDeleteProductIds(array $ids): void
+    {
+        // Mirror of ImportRawMaterials delete order.
+        $morph = self::PRODUCT_MORPH;
+
+        $saleProductIds = Schema::hasTable('sale_products')
+            ? DB::table('sale_products')->whereIn('product_id', $ids)->pluck('id')->all()
+            : [];
+
+        if (! empty($saleProductIds)) {
+            if (Schema::hasTable('sale_product_children')) {
+                DB::table('sale_product_children')->whereIn('sale_product_id', $saleProductIds)->delete();
+            }
+            if (Schema::hasTable('delivery_order_products')) {
+                DB::table('delivery_order_products')->whereIn('sale_product_id', $saleProductIds)->delete();
+            }
+        }
+
+        foreach (['sale_products', 'production_milestone_materials', 'production_milestone_materials_preview',
+                  'material_use_products', 'grn', 'promotions', 'product_children', 'product_costs',
+                  'product_selling_prices', 'product_milestones', 'classification_code_product',
+                  'factory_raw_materials'] as $t) {
+            if (Schema::hasTable($t)) {
+                DB::table($t)->whereIn('product_id', $ids)->delete();
+            }
+        }
+
+        foreach (self::PRODUCT_MORPH_TABLES as [$t, $typeCol, $idCol]) {
+            if (Schema::hasTable($t)) {
+                DB::table($t)->where($typeCol, $morph)->whereIn($idCol, $ids)->delete();
+            }
+        }
+    }
+
+    // ─── Phase 1–3: renumber products ─────────────────────────────────
+
+    private function renumberProducts(): void
+    {
+        $this->info('1. Building products id map');
+        $oldIds = DB::table('products')
+            ->orderBy('type')
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        if (empty($oldIds)) {
+            $this->warn('  No live products — skipping renumber.');
+            return;
+        }
+
+        // old_id → new_id
+        $map = [];
+        foreach ($oldIds as $i => $oldId) {
+            $map[$oldId] = $i + 1;
+        }
+
+        // Short-circuit if already contiguous 1..N.
+        if ($oldIds[0] === 1 && end($oldIds) === count($oldIds)) {
+            $this->line('  products.id already contiguous 1..' . count($oldIds) . ' — skipping.');
+            return;
+        }
+
+        $this->info('2. Shifting products + all product-referencing columns by +' . self::OFFSET);
+        $this->shiftAllProductRefs();
+
+        $this->info('3. Applying final product ids (iterating ' . count($map) . ' rows)');
+        $bar = $this->output->createProgressBar(count($map));
+        $bar->start();
+
+        foreach ($map as $oldId => $newId) {
+            $shifted = $oldId + self::OFFSET;
+
+            // Parent
+            DB::table('products')->where('id', $shifted)->update(['id' => $newId]);
+
+            // Self-FK
+            DB::table('products')->where('hi_ten_stock_code', $shifted)->update(['hi_ten_stock_code' => $newId]);
+
+            // product_id FK tables
+            foreach (self::PRODUCT_ID_TABLES as $t) {
+                if (Schema::hasTable($t)) {
+                    DB::table($t)->where('product_id', $shifted)->update(['product_id' => $newId]);
+                }
+            }
+
+            // sale_enquiries.product_service_interested
+            if (Schema::hasTable('sale_enquiries')) {
+                DB::table('sale_enquiries')
+                    ->where('product_service_interested', $shifted)
+                    ->update(['product_service_interested' => $newId]);
+            }
+
+            // Morph tables
+            foreach (self::PRODUCT_MORPH_TABLES as [$t, $typeCol, $idCol]) {
+                if (Schema::hasTable($t)) {
+                    DB::table($t)
+                        ->where($typeCol, self::PRODUCT_MORPH)
+                        ->where($idCol, $shifted)
+                        ->update([$idCol => $newId]);
+                }
+            }
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info('  Renumbered ' . count($map) . ' products.');
+    }
+
+    private function shiftAllProductRefs(): void
+    {
+        DB::table('products')->update(['id' => DB::raw('id + ' . self::OFFSET)]);
+        DB::table('products')
+            ->whereNotNull('hi_ten_stock_code')
+            ->update(['hi_ten_stock_code' => DB::raw('hi_ten_stock_code + ' . self::OFFSET)]);
+
+        foreach (self::PRODUCT_ID_TABLES as $t) {
+            if (Schema::hasTable($t)) {
+                DB::table($t)
+                    ->whereNotNull('product_id')
+                    ->update(['product_id' => DB::raw('product_id + ' . self::OFFSET)]);
+            }
+        }
+
+        if (Schema::hasTable('sale_enquiries')) {
+            DB::table('sale_enquiries')
+                ->whereNotNull('product_service_interested')
+                ->update(['product_service_interested' => DB::raw('product_service_interested + ' . self::OFFSET)]);
+        }
+
+        foreach (self::PRODUCT_MORPH_TABLES as [$t, $typeCol, $idCol]) {
+            if (Schema::hasTable($t)) {
+                DB::table($t)
+                    ->where($typeCol, self::PRODUCT_MORPH)
+                    ->update([$idCol => DB::raw($idCol . ' + ' . self::OFFSET)]);
+            }
+        }
+    }
+
+    // ─── Phase 4: renumber attachments ────────────────────────────────
+
+    private function renumberAttachments(): void
+    {
+        $this->info('4. Renumbering attachments.id');
+        $oldIds = DB::table('attachments')->orderBy('id')->pluck('id')->all();
+
+        if (empty($oldIds)) {
+            $this->line('  No attachments — skipping.');
+            return;
+        }
+        if ($oldIds[0] === 1 && end($oldIds) === count($oldIds)) {
+            $this->line('  attachments.id already contiguous 1..' . count($oldIds) . ' — skipping.');
+            return;
+        }
+
+        // Shift
+        DB::table('attachments')->update(['id' => DB::raw('id + ' . self::OFFSET)]);
+
+        $bar = $this->output->createProgressBar(count($oldIds));
+        $bar->start();
+        foreach ($oldIds as $i => $oldId) {
+            DB::table('attachments')
+                ->where('id', $oldId + self::OFFSET)
+                ->update(['id' => $i + 1]);
+            $bar->advance();
+        }
+        $bar->finish();
+        $this->newLine();
+        $this->info('  Renumbered ' . count($oldIds) . ' attachments.');
+    }
+
+    // ─── Phase 5: auto-increment reset + summary ──────────────────────
+
+    private function resetAutoIncrements(): void
+    {
+        foreach (['products', 'attachments'] as $t) {
+            $max = (int) DB::table($t)->max('id');
+            DB::statement("ALTER TABLE `{$t}` AUTO_INCREMENT = " . ($max + 1));
+        }
+    }
+
+    private function printSummary(): void
+    {
+        $products = DB::table('products')->selectRaw('MIN(id) mn, MAX(id) mx, COUNT(*) c')->first();
+        $att = DB::table('attachments')->selectRaw('MIN(id) mn, MAX(id) mx, COUNT(*) c')->first();
+
+        $this->newLine();
+        $this->info('Renumber complete.');
+        $this->line("  products:    min={$products->mn}  max={$products->mx}  count={$products->c}");
+        $this->line("  attachments: min={$att->mn}  max={$att->mx}  count={$att->c}");
+    }
+
+    private function deleteAndLog(string $label, \Closure $run): void
+    {
+        $n = $run();
+        $this->line(sprintf('  ✓ %-35s %d deleted', $label, $n));
+    }
+}

--- a/app/Console/Commands/UpdateProductClassificationCode.php
+++ b/app/Console/Commands/UpdateProductClassificationCode.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class UpdateProductClassificationCode extends Command
+{
+    protected $signature = 'app:update-product-classification-code
+        {--code=022 : Classification code to apply to every product}
+        {--dry-run : Show what would change without writing}
+        {--force : Skip the YES confirmation prompt}';
+
+    protected $description = 'Re-syncs every non-soft-deleted product (both finished goods and raw materials/spare parts, across all branches) so that its only classification code is the one given by --code (default 022).';
+
+    private const CHUNK = 500;
+
+    public function handle(): int
+    {
+        $code = trim((string) $this->option('code'));
+        if ($code === '') {
+            $this->error('--code cannot be empty.');
+            return 1;
+        }
+
+        $target = DB::table('classification_codes')->where('code', $code)->first(['id', 'code']);
+        if ($target === null) {
+            $existing = DB::table('classification_codes')->count();
+            $this->error("Classification code '{$code}' not found in classification_codes table ({$existing} codes total). Aborting — create the row first if this is a new code.");
+            return 1;
+        }
+        $targetId = (int) $target->id;
+        $this->info("Target classification code: {$target->code} (id={$targetId})");
+
+        $productIds = DB::table('products')
+            ->whereNull('deleted_at')
+            ->pluck('id')
+            ->map(fn ($v) => (int) $v)
+            ->all();
+
+        $totalProducts = count($productIds);
+        if ($totalProducts === 0) {
+            $this->info('No live products to update.');
+            return 0;
+        }
+        $this->info("Live products: {$totalProducts}");
+
+        $alreadyAttached = [];
+        foreach (array_chunk($productIds, self::CHUNK) as $chunk) {
+            $rows = DB::table('classification_code_product')
+                ->whereIn('product_id', $chunk)
+                ->where('classification_code_id', $targetId)
+                ->pluck('product_id');
+            foreach ($rows as $pid) {
+                $alreadyAttached[(int) $pid] = true;
+            }
+        }
+
+        $detachCount = 0;
+        foreach (array_chunk($productIds, self::CHUNK) as $chunk) {
+            $detachCount += DB::table('classification_code_product')
+                ->whereIn('product_id', $chunk)
+                ->where('classification_code_id', '!=', $targetId)
+                ->count();
+        }
+
+        $attachIds = array_values(array_filter($productIds, fn ($id) => ! isset($alreadyAttached[$id])));
+        $attachCount = count($attachIds);
+
+        $noopCount = 0;
+        foreach (array_chunk($productIds, self::CHUNK) as $chunk) {
+            $rows = DB::table('classification_code_product')
+                ->whereIn('product_id', $chunk)
+                ->select('product_id', DB::raw('COUNT(*) as c'), DB::raw('MAX(classification_code_id) as max_id'), DB::raw('MIN(classification_code_id) as min_id'))
+                ->groupBy('product_id')
+                ->get();
+            foreach ($rows as $r) {
+                if ((int) $r->c === 1 && (int) $r->max_id === $targetId && (int) $r->min_id === $targetId) {
+                    $noopCount++;
+                }
+            }
+        }
+
+        $this->newLine();
+        $this->info('Plan:');
+        $this->line("  Will attach {$target->code} to: {$attachCount} products");
+        $this->line("  Will detach (other codes from these products): {$detachCount} pivot rows");
+        $this->line("  Already exactly [{$target->code}] (no-op): {$noopCount} products");
+
+        if ($this->option('dry-run')) {
+            $this->warn('DRY RUN — no changes were made.');
+            return 0;
+        }
+
+        if ($attachCount === 0 && $detachCount === 0) {
+            $this->info('Nothing to update.');
+            return 0;
+        }
+
+        if (! $this->option('force')) {
+            $msg = "Type YES to apply: attach {$attachCount}, detach {$detachCount} pivot rows";
+            if ($this->ask($msg) !== 'YES') {
+                $this->info('Aborted.');
+                return 0;
+            }
+        }
+
+        $now = now();
+
+        try {
+            DB::transaction(function () use ($productIds, $targetId, $attachIds, $now) {
+                foreach (array_chunk($productIds, self::CHUNK) as $chunk) {
+                    DB::table('classification_code_product')
+                        ->whereIn('product_id', $chunk)
+                        ->where('classification_code_id', '!=', $targetId)
+                        ->delete();
+                }
+
+                foreach (array_chunk($attachIds, self::CHUNK) as $chunk) {
+                    $rows = array_map(fn ($pid) => [
+                        'product_id' => $pid,
+                        'classification_code_id' => $targetId,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ], $chunk);
+                    DB::table('classification_code_product')->insert($rows);
+                }
+            });
+        } catch (\Throwable $e) {
+            $this->error('Update failed: ' . $e->getMessage());
+            return 1;
+        }
+
+        $this->info("Done. Attached {$attachCount} products to {$target->code}; removed {$detachCount} other-code pivot rows.");
+        return 0;
+    }
+}

--- a/app/Console/Commands/UpdateProductUom.php
+++ b/app/Console/Commands/UpdateProductUom.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Branch;
+use App\Models\Product;
+use App\Models\UOM;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+class UpdateProductUom extends Command
+{
+    protected $signature = 'app:update-product-uom
+        {--fg-path= : Override path to FINISH GOOD LIST.xlsx}
+        {--rm-path= : Override path to RAW MATERIALS & SPARE PART LIST.xlsx}
+        {--skip-fg : Skip the finish-good (type=1) phase}
+        {--skip-rm : Skip the raw-material/spare-part (type=2) phase}
+        {--dry-run : Parse and report what would change, without writing}
+        {--force : Skip the YES confirmation prompt}';
+
+    protected $description = 'Realign products.uom (uom.id stored as string) from the master spreadsheets. FG (type=1) reads FINISH GOOD LIST.xlsx; RM/SP (type=2) reads RAW MATERIALS & SPARE PART LIST.xlsx and auto-creates any new UOM names found there.';
+
+    private const FG_DEFAULT_PATH = '/Users/yapyixian/Herd/powercool/FINISH GOOD LIST.xlsx';
+    private const FG_SHEET = 'MASTER';
+    private const FG_HEADER_ROWS = 1;
+    private const FG_SKU_COL = 'D';
+    private const FG_UOM_COL = 'L';
+
+    private const RM_DEFAULT_PATH = '/Users/yapyixian/Herd/powercool/RAW MATERIALS & SPARE PART LIST.xlsx';
+    private const RM_SHEET = 'RAW MATERIALS & SPARE PART LIST';
+    private const RM_HEADER_ROWS = 7;
+    private const RM_SKU_COL = 'C';
+    private const RM_UOM_COL = 'D';
+
+    public function handle(): int
+    {
+        $doFg = ! $this->option('skip-fg');
+        $doRm = ! $this->option('skip-rm');
+
+        if (! $doFg && ! $doRm) {
+            $this->error('Both phases skipped — nothing to do.');
+            return 1;
+        }
+
+        $uomLookup = $this->buildUomLookup();
+
+        // Phase 1: FG (type=1) — aborts on unknown UOM (the FG xlsx has a tightly-controlled vocabulary).
+        $fgPlan = null;
+        if ($doFg) {
+            $fgPath = $this->option('fg-path') ?: self::FG_DEFAULT_PATH;
+            if (! File::exists($fgPath)) {
+                $this->error("FG file not found: {$fgPath}");
+                return 1;
+            }
+            $this->info("Reading FG: {$fgPath}");
+            $fgMap = $this->parseExcel($fgPath, self::FG_SHEET, self::FG_HEADER_ROWS, self::FG_SKU_COL, self::FG_UOM_COL);
+            $this->info('Parsed ' . count($fgMap) . ' SKU rows from sheet "' . self::FG_SHEET . '".');
+
+            $unknown = $this->detectUnknownUoms($fgMap, $uomLookup);
+            if (! empty($unknown)) {
+                $this->error('Aborting: FG xlsx contains UOM names not present in the uom table:');
+                foreach ($unknown as $name => $n) {
+                    $this->line("  - {$name}: {$n} rows");
+                }
+                $this->line('Known UOMs: ' . implode(', ', array_keys($uomLookup)));
+                return 1;
+            }
+
+            $fgPlan = $this->planByName($fgMap, Product::TYPE_PRODUCT, $uomLookup);
+            $this->reportPlan('Finish goods (type=1)', $fgPlan);
+        }
+
+        // Phase 2: RM/SP (type=2) — auto-creates missing UOMs (free-form vocabulary).
+        $rmPlan = null;
+        if ($doRm) {
+            $rmPath = $this->option('rm-path') ?: self::RM_DEFAULT_PATH;
+            if (! File::exists($rmPath)) {
+                $this->error("RM file not found: {$rmPath}");
+                return 1;
+            }
+            $this->info("Reading RM/SP: {$rmPath}");
+            $rmMap = $this->parseExcel($rmPath, self::RM_SHEET, self::RM_HEADER_ROWS, self::RM_SKU_COL, self::RM_UOM_COL);
+            $this->info('Parsed ' . count($rmMap) . ' SKU rows from sheet "' . self::RM_SHEET . '".');
+
+            $rmPlan = $this->planByName($rmMap, Product::TYPE_RAW_MATERIAL, $uomLookup);
+            $this->reportPlan('Raw materials & spare parts (type=2)', $rmPlan);
+        }
+
+        $totalUpdates = ($fgPlan['updateCount'] ?? 0) + ($rmPlan['updateCount'] ?? 0);
+        $totalToCreate = count($rmPlan['uomsToCreate'] ?? []);
+
+        if ($this->option('dry-run')) {
+            $this->warn('DRY RUN — no changes were made.');
+            return 0;
+        }
+
+        if ($totalUpdates === 0 && $totalToCreate === 0) {
+            $this->info('Nothing to update.');
+            return 0;
+        }
+
+        if (! $this->option('force')) {
+            $msg = "Type YES to update {$totalUpdates} product rows";
+            if ($totalToCreate > 0) {
+                $msg .= " (and create {$totalToCreate} new UOM rows)";
+            }
+            if ($this->ask($msg) !== 'YES') {
+                $this->info('Aborted.');
+                return 0;
+            }
+        }
+
+        try {
+            DB::transaction(function () use ($fgPlan, $rmPlan) {
+                $lookup = $this->buildUomLookup();
+
+                if (! empty($rmPlan['uomsToCreate'] ?? [])) {
+                    foreach ($rmPlan['uomsToCreate'] as $name) {
+                        $this->ensureUom($name);
+                    }
+                    $lookup = $this->buildUomLookup();
+                }
+
+                if ($fgPlan !== null) {
+                    $this->applyUpdates($fgPlan['idsByTargetName'], $lookup);
+                }
+                if ($rmPlan !== null) {
+                    $this->applyUpdates($rmPlan['idsByTargetName'], $lookup);
+                }
+            });
+        } catch (\Throwable $e) {
+            $this->error('Update failed: ' . $e->getMessage());
+            return 1;
+        }
+
+        $this->info("Updated {$totalUpdates} product rows" . ($totalToCreate > 0 ? ", created {$totalToCreate} new UOM rows" : '') . '.');
+        return 0;
+    }
+
+    // ─────────────────────── parse + lookup ───────────────────────
+
+    /** @return array<string,string> uppercased SKU -> uppercased UOM name */
+    private function parseExcel(string $path, string $sheetName, int $headerRows, string $skuCol, string $uomCol): array
+    {
+        $reader = IOFactory::createReaderForFile($path);
+        $reader->setReadDataOnly(true);
+        $reader->setLoadSheetsOnly([$sheetName]);
+        $sheet = $reader->load($path)->getSheetByName($sheetName);
+
+        $map = [];
+        $last = $sheet->getHighestRow();
+        $startRow = $headerRows + 1;
+
+        for ($r = $startRow; $r <= $last; $r++) {
+            $sku = trim((string) $sheet->getCell($skuCol . $r)->getCalculatedValue());
+            $uom = trim((string) $sheet->getCell($uomCol . $r)->getCalculatedValue());
+            if ($sku === '' || $uom === '') {
+                continue;
+            }
+            $map[mb_strtoupper($sku)] = mb_strtoupper($uom);
+        }
+
+        return $map;
+    }
+
+    /** @return array<string,int> uppercased UOM name -> uom.id */
+    private function buildUomLookup(): array
+    {
+        $out = [];
+        foreach (DB::table('uom')->get(['id', 'name']) as $row) {
+            $out[mb_strtoupper(trim((string) $row->name))] = (int) $row->id;
+        }
+        return $out;
+    }
+
+    /** @return array<string,int> unknown UOM name -> count */
+    private function detectUnknownUoms(array $skuToUomName, array $uomLookup): array
+    {
+        $unknown = [];
+        foreach ($skuToUomName as $name) {
+            if (! isset($uomLookup[$name])) {
+                $unknown[$name] = ($unknown[$name] ?? 0) + 1;
+            }
+        }
+        return $unknown;
+    }
+
+    private function ensureUom(string $name): UOM
+    {
+        $uom = UOM::withoutGlobalScopes()->firstOrCreate(
+            ['name' => $name],
+            ['is_active' => true]
+        );
+        foreach ([Branch::LOCATION_KL, Branch::LOCATION_PENANG] as $loc) {
+            Branch::withoutGlobalScopes()->firstOrCreate([
+                'object_type' => UOM::class,
+                'object_id' => $uom->id,
+                'location' => $loc,
+            ]);
+        }
+        return $uom;
+    }
+
+    // ─────────────────────── planning ───────────────────────
+
+    /**
+     * Plans updates for a product type, keyed by the target UOM **name** (so the plan stays
+     * meaningful even when the UOM doesn't exist yet — see uomsToCreate).
+     *
+     * @param  array<string,string>  $skuToUomName  uppercased SKU -> uppercased UOM name (xlsx)
+     * @param  int                   $productType   Product::TYPE_PRODUCT or Product::TYPE_RAW_MATERIAL
+     * @param  array<string,int>     $uomLookup     uppercased name -> uom.id (current DB state)
+     * @return array{idsByTargetName: array<string, int[]>, updateCount: int, noopCount: int, unmatchedSkus: array<string,int>, totalProducts: int, uomsToCreate: string[]}
+     */
+    private function planByName(array $skuToUomName, int $productType, array $uomLookup): array
+    {
+        $products = DB::table('products')
+            ->where('type', $productType)
+            ->whereNull('deleted_at')
+            ->get(['id', 'sku', 'uom']);
+
+        $idsByTargetName = [];
+        $noopCount = 0;
+        $unmatchedSkus = [];
+
+        foreach ($products as $p) {
+            $key = mb_strtoupper(trim((string) $p->sku));
+            if (! isset($skuToUomName[$key])) {
+                $unmatchedSkus[$p->sku] = ($unmatchedSkus[$p->sku] ?? 0) + 1;
+                continue;
+            }
+            $targetName = $skuToUomName[$key];
+            $targetId = $uomLookup[$targetName] ?? null; // null -> UOM doesn't exist yet, will be created
+
+            $current = $p->uom === null ? null : (string) $p->uom;
+            if ($targetId !== null && $current === (string) $targetId) {
+                $noopCount++;
+                continue;
+            }
+            $idsByTargetName[$targetName][] = (int) $p->id;
+        }
+
+        $uomsToCreate = [];
+        foreach (array_keys($idsByTargetName) as $name) {
+            if (! isset($uomLookup[$name])) {
+                $uomsToCreate[] = $name;
+            }
+        }
+
+        return [
+            'idsByTargetName' => $idsByTargetName,
+            'updateCount' => array_sum(array_map('count', $idsByTargetName)),
+            'noopCount' => $noopCount,
+            'unmatchedSkus' => $unmatchedSkus,
+            'totalProducts' => $products->count(),
+            'uomsToCreate' => $uomsToCreate,
+        ];
+    }
+
+    // ─────────────────────── apply ───────────────────────
+
+    /**
+     * @param  array<string, int[]>  $idsByTargetName  UOM name -> product ids
+     * @param  array<string, int>    $uomLookup        UOM name -> uom.id (must contain every key in idsByTargetName)
+     */
+    private function applyUpdates(array $idsByTargetName, array $uomLookup): void
+    {
+        foreach ($idsByTargetName as $name => $ids) {
+            $id = $uomLookup[$name] ?? null;
+            if ($id === null) {
+                throw new \RuntimeException("UOM lookup missing entry for '{$name}' at apply time");
+            }
+            foreach (array_chunk($ids, 500) as $chunk) {
+                DB::table('products')->whereIn('id', $chunk)->update([
+                    'uom' => (string) $id,
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    // ─────────────────────── reporting ───────────────────────
+
+    /**
+     * @param array{idsByTargetName: array<string, int[]>, updateCount: int, noopCount: int, unmatchedSkus: array<string,int>, totalProducts: int, uomsToCreate: string[]} $plan
+     */
+    private function reportPlan(string $title, array $plan): void
+    {
+        $this->newLine();
+        $this->info($title . ' — preview:');
+        $this->line("  Live products: {$plan['totalProducts']}");
+        $this->line("  Will update: {$plan['updateCount']}");
+        $this->line("  Already correct (no-op): {$plan['noopCount']}");
+        $this->line('  Unmatched SKUs (not in xlsx): ' . count($plan['unmatchedSkus']));
+
+        if (! empty($plan['idsByTargetName'])) {
+            $this->line('  By target UOM:');
+            ksort($plan['idsByTargetName']);
+            foreach ($plan['idsByTargetName'] as $name => $ids) {
+                $marker = in_array($name, $plan['uomsToCreate'], true) ? ' (NEW — will be created)' : '';
+                $this->line(sprintf('    - %s%s: %d', $name, $marker, count($ids)));
+            }
+        }
+
+        if (! empty($plan['uomsToCreate'])) {
+            $this->line('  UOMs to create: ' . implode(', ', $plan['uomsToCreate']));
+        }
+
+        if (! empty($plan['unmatchedSkus'])) {
+            $sample = array_slice(array_keys($plan['unmatchedSkus']), 0, 30);
+            $this->line('  Sample unmatched SKUs (first ' . count($sample) . ' of ' . count($plan['unmatchedSkus']) . '):');
+            foreach ($sample as $sku) {
+                $this->line('    - ' . $sku);
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -711,6 +711,8 @@ class ProductionController extends Controller
                 'production_id' => $newProduction->id,
                 'milestone_id' => $milestone->id,
                 'sequence' => $milestone->pivot->sequence ?? 1,
+                'submitted_at' => null,
+                'submitted_by' => null,
             ]);
 
             // Copy material preview records
@@ -1010,7 +1012,7 @@ class ProductionController extends Controller
         // Only allow rejection when production is in progress
         $pms = $this->prodMs::where('id', $req->production_milestone_id)->first();
         $production = Production::where('id', $pms->production_id)->first();
-        if (strtolower($production->status) != 'in progress') {
+        if ($production->status != Production::STATUS_DOING) {
             return Response::json([
                 'errors' => [
                     'general' => 'Rejection is not allowed when production is not in progress',

--- a/app/Models/Production.php
+++ b/app/Models/Production.php
@@ -190,7 +190,7 @@ class Production extends Model
         $milestone_completed_count = ProductionMilestone::where('production_id', $production->id)->whereNotNull('submitted_at')->count();
 
         if ($milestone_all_count == 0) {
-            $progress = number_format(1 * 100, 2);
+            $progress = number_format(0, 2);
         } else {
             $progress = number_format(($milestone_completed_count / $milestone_all_count) * 100, 2);
         }

--- a/app/Services/ProductMergeService.php
+++ b/app/Services/ProductMergeService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+class ProductMergeService
+{
+    /**
+     * Reverse the admin's symbol-safe filename substitutions to recover the
+     * original SKU. Filenames cannot contain /, *, or " so the admin writes
+     * them as !, @, and ' (or nothing) respectively.
+     */
+    public static function normalizeFromPhotoFilename(string $name): string
+    {
+        $normalized = trim($name);
+        $normalized = strtr($normalized, [
+            '!' => '/',
+            '@' => '*',
+            "'" => '"',
+        ]);
+
+        return $normalized;
+    }
+
+    /**
+     * Ordered list of candidate SKU variants to try when matching a photo
+     * filename against the product SKU map. The seeder tries each in order
+     * and stops at the first hit.
+     *
+     * Variants cover the two recurring ambiguities from `sp-rm-feedback.txt`:
+     *   - `"` is sometimes dropped in filenames ("NO NEED BORDER")
+     *   - `_` substitutes for either `/` or `"` (filesystems don't accept `/`)
+     *
+     * @return string[] distinct candidates, already normalized by
+     *                 normalizeFromPhotoFilename().
+     */
+    public static function photoFilenameCandidates(string $name): array
+    {
+        $base = self::normalizeFromPhotoFilename($name);
+
+        $variants = [
+            $base,
+            str_replace('"', '', $base),
+            str_replace('_', '/', $base),
+            str_replace('_', '"', $base),
+        ];
+
+        // Also try each variant with a trailing "-N" photo-index stripped
+        // (e.g. COIL-100-7.5P-400-1 → COIL-100-7.5P-400) to keep the existing
+        // multi-photo fallback behaviour from SparePartPhotoSeeder.
+        $extras = [];
+        foreach ($variants as $v) {
+            $stripped = preg_replace('/[-_ ](\d+)$/', '', $v);
+            if ($stripped !== null && $stripped !== $v) {
+                $extras[] = $stripped;
+            }
+        }
+
+        return array_values(array_unique(array_merge($variants, $extras)));
+    }
+}

--- a/app/Services/SparePartPhotoOverrides.php
+++ b/app/Services/SparePartPhotoOverrides.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Manual filename → SKU overrides for the spare-part / raw-material photo
+ * seeder. Compiled from `sp-rm-feedback.txt` in the repo root.
+ *
+ * Keys are the photo filename base (no extension), lowercased + trimmed.
+ * Values are either:
+ *   ['__delete__'] — skip the photo (user marked it for deletion / wrong code)
+ *   [sku, ...]     — attach the photo to every listed SKU (1..N products)
+ *
+ * Automatic char-substitution rules (handled by
+ * ProductMergeService::normalizeFromPhotoFilename) are NOT duplicated here —
+ * this file only contains renames that can't be recovered deterministically.
+ *
+ * Sources merged (file wins on conflict):
+ *   1. Hardcoded map below — historical entries for PHOTOS 1–5.
+ *   2. `sp-rm-feedback.txt` — live, editable file at the repo root. Each line:
+ *        [unmatched_file] [FOLDER] LHS = RHS
+ *        [unmatched_file] [FOLDER] LHS = __DELETE__      (skip the photo)
+ *        [unmatched_file] [FOLDER] LHS = RHS1 + RHS2     (one-to-many)
+ */
+class SparePartPhotoOverrides
+{
+    public const DELETE = '__delete__';
+
+    private const FEEDBACK_PATH = __DIR__ . '/../../../sp-rm-feedback.txt';
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function map(): array
+    {
+        $hardcoded = self::hardcodedMap();
+        $fromFile = self::parseFeedbackFile();
+
+        // File wins on conflict so edits to sp-rm-feedback.txt take effect
+        // without a PHP change.
+        return array_merge($hardcoded, $fromFile);
+    }
+
+    /**
+     * Parse `sp-rm-feedback.txt` lines of the form:
+     *   [unmatched_file] [SPARE PART PHOTOS N] LHS = RHS
+     * Returns keyed map compatible with `map()`.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private static function parseFeedbackFile(): array
+    {
+        if (! is_file(self::FEEDBACK_PATH)) {
+            return [];
+        }
+
+        $out = [];
+        $handle = fopen(self::FEEDBACK_PATH, 'r');
+        if ($handle === false) {
+            return [];
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $line = rtrim($line, "\r\n");
+            if ($line === '' || str_starts_with(ltrim($line), '#')) {
+                continue;
+            }
+            // Only process unmatched_file rows — no_photo rows have no replacement target.
+            if (! preg_match('/^\[unmatched_file\]\s*\[[^\]]+\]\s*(.+?)\s*=\s*(.+)$/', $line, $m)) {
+                continue;
+            }
+            $lhs = trim($m[1]);
+            $rhs = trim($m[2]);
+            if ($lhs === '' || $rhs === '') {
+                continue;
+            }
+
+            $key = mb_strtolower(trim($lhs));
+
+            if (strcasecmp($rhs, '__DELETE__') === 0 || strcasecmp($rhs, 'DELETE') === 0) {
+                $out[$key] = [self::DELETE];
+                continue;
+            }
+
+            // Support `RHS1 + RHS2` one-to-many syntax (space-padded `+`).
+            $targets = array_values(array_filter(array_map('trim', preg_split('/\s+\+\s+/', $rhs))));
+            if (! empty($targets)) {
+                $out[$key] = $targets;
+            }
+        }
+        fclose($handle);
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private static function hardcodedMap(): array
+    {
+        // Build once with original-case SKUs so the data is readable.
+        $raw = [
+            // ── Spare part renames (photo file → target SKU) ────────────────
+            'ACC-VKZ168CU' => ['COMP-VKZ168CU'],
+            'ASC-617 X 266 C' => ['ASC-617 X 266 [1DT]', 'ASC-617 X 266 C'],
+            'BCV-1D-1' => ['BCV-1D'],
+            'COIL-100-7.5P-400-1' => ['COIL-100-7.5P-400'],
+            'COIL-100-7.5P-400-2' => ['COIL-100-7.5P-400'],
+            'COIL-2@50-4.5P-L900' => ['COIL-2*50-4.5P-L900'],
+            'COIL-2@50-4.5P-L900-1' => ['COIL-2*50-4.5P-L900'],
+            'COIL-2@50-4.5P-L900-2' => ['COIL-2*50-4.5P-L900'],
+            'COIL-3/8 X 4R X 5TH' => ['COIL-3/8" X 4R X 5TH'],
+            'COIL-3!8 x 4R x 5TH' => ['COIL-3/8" X 4R X 5TH'],
+            'COIL-3/8 X 4R X 6TH-(1IN1OUT)' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3!8" x 4R x 6TH-(1IN1O)' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3/8 X 4R X 6TH-(1IN1OUT)-1' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3/8 X 4R X 6TH-(1IN1OUT)-2' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3/8 X 4TH X 1400MM' => ['COIL-3/8" x 4TH x 1400MM'],
+            'COIL-3/8 X 4TH X 1400MM-1' => ['COIL-3/8" x 4TH x 1400MM'],
+            'COIL-3/8 X 4TH X 1400MM-2' => ['COIL-3/8" x 4TH x 1400MM'],
+            'COIL-3/8 X 4TH X 1400MM-3' => ['COIL-3/8" x 4TH x 1400MM'],
+            'COIL-3/8 X 5R' => ['COIL-3/8" x 5R'],
+            'COIL-3/8 X 5R-1' => ['COIL-3/8" x 5R'],
+            'COIL-3/8 X 5R-2' => ['COIL-3/8" x 5R'],
+            'COIL-3/8*4R* 550MM (3DFB)' => ['COIL-3/8*4R* 550MM [3DFB]'],
+            'COIL-3/8*4R* 550MM (3DFB)-1' => ['COIL-3/8*4R* 550MM [3DFB]'],
+            'COIL-3/8*4R* 550MM (3DFB)-2' => ['COIL-3/8*4R* 550MM [3DFB]'],
+            'COIL-5 X 4 X 1200' => ['COIL-5 x 4 x 1280'],
+            'COMP-L58CU1' => [self::DELETE],
+            'COMP-NEU2178GK' => ['ACC-NEU2178GK'],
+
+            'COND-3 X 10 X 360-L' => ['COND-3 x 10 x 360'],
+            'COND-3 X 10 X 360-R' => ['COND-3 x 10 x 360'],
+            'COND-3 X 12 X 360-L' => ['COND-3 x 12 x 360'],
+            'COND-3 X 12 X 360-R' => ['COND-3 x 12 x 360'],
+            'COND-4 X 10 X 320-L' => ['COND-4 x 10 x 320'],
+            'COND-4 X 10 X 320-R' => ['COND-4 x 10 x 320'],
+            'COND-4 X 10 X 580-L' => ['COND-4 x 10 x 580'],
+            'COND-4 X 10 X 580-R' => ['COND-4 x 10 x 580'],
+            'COND-4 X 10 X 800-L' => ['COND-4 x 10 x 800'],
+            'COND-4 X 10 X 800-R' => ['COND-4 x 10 x 800'],
+
+            'CP T - 1 4' => ['CP T - 1/4'],
+            'CR-8" PLT' => ["CR-8' PLT"],
+            'DIG-HK 183' => ['DIG-HK183'],
+            'DIG-SF401' => ['DIG-SF401L'],
+            'DIG-SF401-1' => ['DIG-SF401L'],
+            'DIMMER 3 3 600W' => ['DIMMER 3*3 600W'],
+            'DIV STICK-19' => ['DIV STICK-19"'],
+            'DIV STICK-21' => ['DIV STICK-21"'],
+            'DOOR STOPPER' => ['STICKER-DR ST'],
+            'DR SPR 2.3@ X 14.4 X 16.5' => ['DR SPR 2.3*14.4*16.5'],
+            'DRI BIT 5/32' => ['DRI BIT - 5/32'],
+            'DRILL BIT 7/32' => ['DRI BIT - 7/32'],
+            'DS-500X40' => ['DS-500*40'],
+            'FM-FSY12038HA2BL' => ['VFAN 12038'],
+            'FN-11' => ['FN-11"'],
+            'FN-12' => ['FN-12"'],
+            'FN-8_' => ['FN-8"'],
+            'FN-8' => ['FN-8"'],
+            // Additional mappings derived from existing SKUs following the
+            // same NO-BORDER / rename conventions in sp-rm-feedback.txt.
+            'ADJ LEG 4' => ['ADJ LEG 4"'],
+            'ADJ LEG 6' => ['ADJ LEG 6"'],
+            'ADJ LEG 7' => ['ADJ LEG 7"'],
+            'ADJ LEG 8' => ['ADJ LEG 8"'],
+            'LATCH-3' => ['LATCH-3"'],
+            'LED-1800M' => ['LED-1800MM'],
+            'VFAN NET SQ' => ['FN-VFAN NET SQ'],
+            'STICKER AI+INVERTER' => ['STICKER-AI INVERTER'],
+            // Alternate (no-quote) filenames for COIL-3/8" x 4R x 6TH-(1IN1O).
+            'COIL-3/8 x 4R x 6TH-(1IN1O)' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3/8 x 4R x 6TH-(1IN1O)-1' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            'COIL-3/8 x 4R x 6TH-(1IN1O)-2' => ['COIL-3/8" x 4R x 6TH-(1IN1O)'],
+            // Typo corrections + alternate-form filenames.
+            'S.VLAVE-FDF3408' => ['S.VALVE-FDF3408'],
+            'SCR-12 X 1 3/4' => ['SCR-12 X 1 3/4"'],
+            'SHEL-17 X 22' => ['SHEL-17  X 22'], // SKU has two spaces between 17 and X
+            'SHEL-21 6/8 X 21 B' => ['SHEL-21"6/8 X 21 B'],
+            'FO-1/2x2x4' => ['FO-1/2x2x4'], // normalizer handles !→/
+            'FO-2 1/2x2x4' => ['FO-21/2X2X4'],
+            'FS-10' => ['FS-10"'],
+            'G.BRACKET 14' => ['G.BRACKET 14"'],
+            'G.BRACKET 16' => ['G.BRACKET 16"'],
+            'G.BRACKET 18' => ['G.BRACKET 18"'],
+            'GI-0.40 X 4" X 8"' => ["GI-0.40 X 4' X 8'"],
+            'GI-0.50 X 4" X 8"' => ["GI-0.50 X 4' X 8'"],
+            'GI-0.60 X 4" X 8"' => ["GI-0.60 X 4' X 8'"],
+
+            'GLS-533 X 1418 X 3 CG' => ['GLS-533*1418*3 CG'],
+            'GLS-533 X 1494 KG' => ['GLS-533*1494 KG'],
+            'GLS-533 X 900 CG' => ['GLS-533*900 CG'],
+            'GLS-546 X 1396 X 3 CG' => ['GLS-546*1396*3 CG'],
+            'GLS-552 X 1403 CG' => ['GLS-552*1403 CG'],
+            'GLS-552 X 1403 KG' => ['GLS-552*1403 KG'],
+            'GLS-724 X 1479 CG' => ['GLS-724*1479 CG'],
+            'GLS-LOW E 533 X 1494' => ['GLS-LOW E 533*1494'],
+
+            'HDL-WHI RECESSED [DISPLAY]' => ['HDL-WHI RECCESSED [DISPLAY]'],
+            'HEA-U' => ['HEA-U-CU'],
+
+            'LED SC-FX 1200MM 2700K 12W' => ['LED-1200MM'],
+            'LED SC-FX 1200MM 2700K 12W-1' => ['LED-1200MM'],
+            'LED SC-FX 600MM 2700K 6W' => ['LED-600MM'],
+            'LED SC-FX 600MM 2700K 6W-1' => ['LED-600MM'],
+            'LED SC-FX 900MM 2700K 9W' => ['LED-900MM'],
+            'LED SC-FX 900MM 2700K 9W-1' => ['LED-900MM'],
+
+            'MSP-1.5X4X8' => ['MSP-1.5*4*8'],
+            'MSP-2.5X4X8' => ['MSP-2.5*4*8'],
+            'MSP-3X4X8' => ['MSP-3*4*8'],
+            'OTH-TRUNKING 2 X 2' => ['OTH-TRUNKING 2*2'],
+
+            'PLAS-WPIPE (1)' => ['PLAS-WPIPE'],
+            'PLY-12MM X 4" X 8"' => ["PLY-12MM X 4' X 8'"],
+            'PLY-12MM X 4" X 8" - 1' => ["PLY-12MM X 4' X 8'"],
+            'PLY-15MM X 4" X 8"' => ["PLY-15MM X 4' X 8'"],
+            'PLY-15MM X 4" X 8" - 1' => ["PLY-15MM X 4' X 8'"],
+            'PLY-18MM X 4" X 8"' => ["PLY-18MM X 4' X 8'"],
+            'PLY-18MM X 4" X 8" - 1' => ["PLY-18MM X 4' X 8'"],
+            'PLY-25MM X 4" X 8"' => ["PLY-25MM X 4' X 8'"],
+            'PLY-25MM X 4" X 8" - 1' => ["PLY-25MM X 4' X 8'"],
+            'PLY-3MM X 4" X 8"' => ["PLY-3MM X 4' X 8'"],
+            'PLY-3MM X 4" X 8" - 1' => ["PLY-3MM X 4' X 8'"],
+            'PLY-6MM X 4" X 8"' => ["PLY-6MM X 4' X 8'"],
+            'PLY-6MM X 4" X 8" - 1' => ["PLY-6MM X 4' X 8'"],
+            'PLY-9MM X 4" X 8"' => ["PLY-9MM X 4' X 8'"],
+            'PLY-9MM X 4" X 8" - 1' => ["PLY-9MM X 4' X 8'"],
+
+            'RELAY 8 PIN' => ['ACC-RELAY 8PINS'],
+            'S.FILM 4' => ['S.FILM 4"'],
+            'S.FILM 4-1' => ['S.FILM 4"'],
+            'S/S-3@63@6' => ['S/S-3*63*6'],
+
+            'SCR-1 2" X 5"' => ['SCR-1/2"X5"'],
+            'SCR-10 X 1 2' => ['SCR-10 X 1/2'],
+            'SCR-10 X 5 8' => ['SCR-10 X 5/8'],
+            'SCR-12 X 1 1 2' => ['SCR-12 X 1 1/2'],
+            'SCR-12 X 1 3 4' => ['SCR-12 X 1 3/4"'],
+            'SCR-3_4 X 4' => ['SCR-3/4 X 4'],
+            'SCR-6 X 3 4' => ['SCR-6 X 3/4'],
+            'SCR-6 X 3 8' => ['SCR-6 X 3/8'],
+            'SCR-8 X 3 4' => ['SCR-8 X 3/4'],
+            'SCR-M5 X 8MM SS' => ['SCR-M5 X 8MM S/S'],
+
+            'SENSOR COVER' => ['ACC-DIG-SENS COV'],
+            'SHEL-20 1_2 X 22' => ['SHEL-20 1/2 X 22'],
+            'SHEL-20 6 8 X 22' => ['SHEL-20 6/8 X 22'],
+            'SHEL-21 1_2 X 20 6_8' => ['SHEL-21 1/2 X 20 6/8'],
+            'SHEL-21 6_8 X 21 DIV' => ['SHEL-21 6/8 X 21 DIV'],
+            'SHEL-21 X 20 1 2' => ['SHEL-21 X 20 1/2'],
+            'SHEL-21"6_8 X 21 B' => ['SHEL-21"6/8 X 21 B'],
+            'SHEL-533 X 390 DIV' => ['SHEL-533*390 DIV'],
+            'SHEL-584 X 390 DIV' => ['SHEL-584*390 DIV'],
+
+            'ST-0.45 X 4 X 8 430 2B' => ['ST-0.45*4*8 430 2B'],
+            'ST-0.5 X 4 X 8 430 BA PVC' => ['ST-0.5*4*8 430 BA PVC'],
+
+            'STICKER FRAGILE' => ['STICKER-FRAGILE'],
+            'STICKER I-MAX' => ['STICKER-IMAX'],
+            'STICKER MAINTENANCE' => ['STICKER-MT V2'],
+            'STICKER PENGUIN IMAX' => [self::DELETE],
+            'STICKER TARIK' => ['STICKER-PULL (L)', 'STICKER-PULL (R)'],
+            'STICKER-1212 X 275' => ['STICKER-1212*275'],
+            'STICKER-1832 X 275' => ['STICKER-1832*275'],
+            'STICKER-3YEAR - +INV' => ['STICKER-3YEAR'],
+            'STICKER-B.MSIA (2)' => ['STICKER-B.MSIA'],
+            'STICKER-IMAX 65 X 27' => ['STICKER-IMAX 65*27'],
+            'STICKER-IMAX BLUE 72 X 32' => ['STICKER-IMAX BLUE 72*32'],
+            'Service Sticker 3% 65x65 mm' => ['STICKER-SERV'],
+
+            'TOOLS-1_4BEN' => ['TOOLS-1/4BEN'],
+            'TOOLS-3_8BEN' => ['TOOLS-3/8BEN'],
+            'WIRE-2C 23 0.14' => ['WIRE-2C 23/0.14'],
+            'WIRE-6MM BLACK' => ['WIRE-6MM BK'],
+        ];
+
+        // Lowercase the keys once so lookup is case-insensitive.
+        $out = [];
+        foreach ($raw as $k => $v) {
+            $out[mb_strtolower(trim($k))] = $v;
+        }
+        return $out;
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -31,6 +31,7 @@ class DatabaseSeeder extends Seeder
             StateCitySeeder::class,
             UOMSeeder::class,
             VehicleSeeder::class,
+            VehicleRoadTaxSeeder::class,
         ]);
     }
 }

--- a/database/seeders/SparePartPhotoSeeder.php
+++ b/database/seeders/SparePartPhotoSeeder.php
@@ -4,7 +4,10 @@ namespace Database\Seeders;
 
 use App\Models\Attachment;
 use App\Models\Product;
+use App\Services\ProductMergeService;
+use App\Services\SparePartPhotoOverrides;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
@@ -20,17 +23,18 @@ class SparePartPhotoSeeder extends Seeder
         if ($dryRun) {
             $this->command->info('*** DRY RUN MODE — no files will be copied or records created ***');
         }
-        $basePath = base_path('../');
+        $basePath = base_path('../photos/');
         $folders = [
-            $basePath . 'SPARE PART PHOTOS 1',
-            $basePath . 'SPARE PART PHOTOS 2',
-            $basePath . 'SPARE PART PHOTOS 3',
-            $basePath . 'SPARE PART PHOTOS 4',
-            $basePath . 'SPARE PART PHOTOS 5',
+            // $basePath . 'SPARE PART PHOTOS 1',
+            // $basePath . 'SPARE PART PHOTOS 2',
+            // $basePath . 'SPARE PART PHOTOS 3',
+            // $basePath . 'SPARE PART PHOTOS 4',
+            // $basePath . 'SPARE PART PHOTOS 5',
+            $basePath . 'SPARE PART PHOTOS 6',
         ];
 
         // Build SKU lookup: lowercase SKU => [product IDs]
-        $spareParts = Product::where('is_sparepart', true)->select('id', 'sku')->get();
+        $spareParts = Product::where('type', Product::TYPE_RAW_MATERIAL)->select('id', 'sku')->get();
         $skuMap = [];
         foreach ($spareParts as $part) {
             $key = mb_strtolower(trim($part->sku));
@@ -59,6 +63,9 @@ class SparePartPhotoSeeder extends Seeder
         $totalAttachments = 0;
         $skipped = 0;
         $unmatched = [];
+        $deletedByOverride = 0;
+
+        $overrides = SparePartPhotoOverrides::map();
 
         foreach ($folders as $folder) {
             if (!File::isDirectory($folder)) {
@@ -76,22 +83,53 @@ class SparePartPhotoSeeder extends Seeder
                     continue;
                 }
 
-                // Normalize filename to SKU
                 $baseName = pathinfo($filename, PATHINFO_FILENAME);
-                $baseName = trim($baseName);
-                // Map characters: ! -> /, ' -> "
-                $normalized = str_replace(['!', "'"], ['/', '"'], $baseName);
-                // Strip trailing -N suffix (multi-photo indicator)
-                $skuName = preg_replace('/[-_ ](\d+)$/', '', $normalized);
-                $skuKey = mb_strtolower(trim($skuName));
 
-                if (!isset($skuMap[$skuKey])) {
+                // 1. Explicit overrides (from sp-rm-feedback.txt).
+                // Try both the raw filename AND the normalized form as the
+                // override key, since the override map is authored against
+                // the SKU-style characters (`/`, `"`, `*`) while filenames on
+                // disk use the safe replacements (`!`, `'`, `@`).
+                $normalizedBase = ProductMergeService::normalizeFromPhotoFilename($baseName);
+                $rawKey = mb_strtolower(trim($baseName));
+                $normKey = mb_strtolower(trim($normalizedBase));
+                $targets = $overrides[$rawKey] ?? $overrides[$normKey] ?? null;
+                $productIds = null;
+                $skuName = $baseName;
+
+                if ($targets !== null) {
+                    if ($targets === [SparePartPhotoOverrides::DELETE]) {
+                        $deletedByOverride++;
+                        continue;
+                    }
+                    $productIds = [];
+                    foreach ($targets as $targetSku) {
+                        $k = mb_strtolower(trim($targetSku));
+                        if (isset($skuMap[$k])) {
+                            $productIds = array_merge($productIds, $skuMap[$k]);
+                        }
+                    }
+                    $productIds = array_values(array_unique($productIds));
+                    $skuName = implode(' + ', $targets);
+                }
+
+                // 2. Normalizer candidates (!-/-@-*-'-" + _→/ + _→" + strip trailing -N).
+                if ($productIds === null || empty($productIds)) {
+                    foreach (ProductMergeService::photoFilenameCandidates($baseName) as $candidate) {
+                        $k = mb_strtolower(trim($candidate));
+                        if (isset($skuMap[$k])) {
+                            $productIds = $skuMap[$k];
+                            $skuName = $candidate;
+                            break;
+                        }
+                    }
+                }
+
+                if ($productIds === null || empty($productIds)) {
                     $folderName = basename($folder);
                     $unmatched[$skuName] = $unmatched[$skuName] ?? $folderName;
                     continue;
                 }
-
-                $productIds = $skuMap[$skuKey];
 
                 foreach ($productIds as $productId) {
                     // Check if this exact image already exists for this product (idempotent)
@@ -131,25 +169,36 @@ class SparePartPhotoSeeder extends Seeder
         $this->command->info("  Attachments created: {$totalAttachments}");
         $this->command->info("  Files copied: {$totalCopied}");
         $this->command->info("  Skipped (already exist): {$skipped}");
+        $this->command->info("  Deleted by override: {$deletedByOverride}");
         $this->command->info("  Unmatched photo names: " . count($unmatched));
 
-        if (count($unmatched) > 0) {
-            $unmatchedFile = base_path('../unmatched_spare_part_photos.txt');
-            ksort($unmatched);
-            $lines = [];
-            foreach ($unmatched as $name => $folderName) {
-                $lines[] = "[{$folderName}] {$name}";
-            }
-            File::put($unmatchedFile, implode(PHP_EOL, $lines) . PHP_EOL);
-            $this->command->warn("Unmatched photos written to: {$unmatchedFile}");
+        // Complementary: spare-part / raw-material SKUs that ended up with
+        // zero attachments (no photo file exists for them on disk).
+        $attachedProductIds = Attachment::where('object_type', Product::class)
+            ->whereIn('object_id', $spareParts->pluck('id'))
+            ->pluck('object_id')
+            ->unique();
+
+        $unattached = $spareParts->reject(fn ($p) => $attachedProductIds->contains($p->id));
+        $this->command->info("  SKUs without any photo: " . $unattached->count());
+
+        if (!$dryRun) {
+            $this->writeMergedReport(
+                base_path('../sp_rm_photo_report.txt'),
+                'Spare Part / Raw Material Photo Report',
+                $unmatched,
+                $unattached->pluck('id')->all()
+            );
         }
 
-        // ── MFG / Finished Goods Photos ──
-        $mfgFolder = $basePath . 'MFG';
-        if (!File::isDirectory($mfgFolder)) {
-            $this->command->warn("MFG folder not found: {$mfgFolder}");
+        // ── Finished Goods Photos ──
+        $fgParent = $basePath . 'FINISHED GOOD PHOTOS - 14.04.2026';
+        if (!File::isDirectory($fgParent)) {
+            $this->command->warn("Finished goods folder not found: {$fgParent}");
             return;
         }
+
+        $mfgFolders = collect(File::directories($fgParent));
 
         // Build finished-goods SKU lookup
         $finishedGoods = Product::withoutGlobalScopes()
@@ -167,7 +216,7 @@ class SparePartPhotoSeeder extends Seeder
         $mfgSkipped = 0;
         $mfgUnmatched = [];
 
-        $mfgFiles = File::files($mfgFolder);
+        $mfgFiles = $mfgFolders->flatMap(fn ($dir) => File::files($dir));
 
         foreach ($mfgFiles as $file) {
             $filename = $file->getFilename();
@@ -177,13 +226,33 @@ class SparePartPhotoSeeder extends Seeder
                 continue;
             }
 
-            $baseName = trim(pathinfo($filename, PATHINFO_FILENAME));
-            // Strip trailing -N suffix (multi-photo indicator)
-            $skuName = preg_replace('/[-_ ](\d+)$/', '', $baseName);
+            $rawBase = pathinfo($filename, PATHINFO_FILENAME);
+            $baseName = ProductMergeService::normalizeFromPhotoFilename($rawBase);
+            $skuName = $baseName;
             $skuKey = mb_strtolower(trim($skuName));
 
+            // Try every normalizer candidate (handles stripped `"` etc.).
             if (!isset($mfgSkuMap[$skuKey])) {
-                $mfgUnmatched[$skuName] = $mfgUnmatched[$skuName] ?? 'MFG';
+                foreach (ProductMergeService::photoFilenameCandidates($rawBase) as $candidate) {
+                    $k = mb_strtolower(trim($candidate));
+                    if (isset($mfgSkuMap[$k])) {
+                        $skuName = $candidate;
+                        $skuKey = $k;
+                        break;
+                    }
+                }
+            }
+            if (!isset($mfgSkuMap[$skuKey])) {
+                $stripped = preg_replace('/[-_ ](\d+)$/', '', $baseName);
+                $strippedKey = mb_strtolower(trim($stripped));
+                if (isset($mfgSkuMap[$strippedKey])) {
+                    $skuName = $stripped;
+                    $skuKey = $strippedKey;
+                }
+            }
+
+            if (!isset($mfgSkuMap[$skuKey])) {
+                $mfgUnmatched[$skuName] = $mfgUnmatched[$skuName] ?? basename($file->getPath());
                 continue;
             }
 
@@ -226,15 +295,71 @@ class SparePartPhotoSeeder extends Seeder
         $this->command->info("  Skipped (already exist): {$mfgSkipped}");
         $this->command->info("  Unmatched photo names: " . count($mfgUnmatched));
 
-        if (count($mfgUnmatched) > 0) {
-            $unmatchedMfgFile = base_path('../unmatched_mfg_photos.txt');
-            ksort($mfgUnmatched);
-            $mfgLines = [];
-            foreach ($mfgUnmatched as $name => $folderName) {
-                $mfgLines[] = "[{$folderName}] {$name}";
-            }
-            File::put($unmatchedMfgFile, implode(PHP_EOL, $mfgLines) . PHP_EOL);
-            $this->command->warn("Unmatched MFG photos written to: {$unmatchedMfgFile}");
+        // Same pattern as SP/RM: list finished-goods SKUs with no photo.
+        $mfgAttachedIds = Attachment::where('object_type', Product::class)
+            ->whereIn('object_id', $finishedGoods->pluck('id'))
+            ->pluck('object_id')
+            ->unique();
+        $mfgUnattached = $finishedGoods->reject(fn ($fg) => $mfgAttachedIds->contains($fg->id));
+        $this->command->info("  SKUs without any photo: " . $mfgUnattached->count());
+
+        if (!$dryRun) {
+            $this->writeMergedReport(
+                base_path('../finished_good_photo_report.txt'),
+                'Finished Good Photo Report',
+                $mfgUnmatched,
+                $mfgUnattached->pluck('id')->all()
+            );
         }
+    }
+
+    /**
+     * Write a single merged report that lists both photo files with no
+     * matching SKU ("unmatched_file") and SKUs with no photo file
+     * ("no_photo") — each row prefixed with the reason.
+     *
+     * @param  array<string,string>  $unmatchedFiles  base-filename → folder
+     * @param  array<int,int>        $unattachedIds   product ids with no photo
+     */
+    private function writeMergedReport(string $path, string $title, array $unmatchedFiles, array $unattachedIds): void
+    {
+        ksort($unmatchedFiles);
+
+        $skuRows = empty($unattachedIds) ? collect() : DB::table('products')
+            ->leftJoin('inventory_categories', 'products.inventory_category_id', '=', 'inventory_categories.id')
+            ->whereIn('products.id', $unattachedIds)
+            ->orderByRaw('CASE WHEN products.type = 2 THEN products.is_sparepart ELSE NULL END')
+            ->orderBy('inventory_categories.name')
+            ->orderBy('products.sku')
+            ->get(['products.sku', 'products.type', 'products.is_sparepart', 'products.model_desc', 'inventory_categories.name as cat']);
+
+        $lines = [];
+        $lines[] = "# {$title}";
+        $lines[] = '# generated: ' . now()->toDateTimeString();
+        $lines[] = '# reasons:';
+        $lines[] = '#   unmatched_file = photo file exists on disk but no product SKU matches';
+        $lines[] = '#   no_photo       = product SKU exists but no photo file attached';
+        $lines[] = '# summary: unmatched_file=' . count($unmatchedFiles) . '  no_photo=' . $skuRows->count();
+        $lines[] = '';
+
+        foreach ($unmatchedFiles as $name => $folderName) {
+            $lines[] = sprintf('[unmatched_file] [%s] %s', $folderName, $name);
+        }
+
+        if ($skuRows->isNotEmpty() && !empty($unmatchedFiles)) {
+            $lines[] = '';
+        }
+
+        foreach ($skuRows as $r) {
+            $tag = match (true) {
+                (int) $r->type === Product::TYPE_PRODUCT => 'FG',
+                (bool) $r->is_sparepart                  => 'SP',
+                default                                  => 'RM',
+            };
+            $lines[] = sprintf('[no_photo]       [%s] [%s] %s — %s', $tag, $r->cat ?? '-', $r->sku, $r->model_desc);
+        }
+
+        File::put($path, implode(PHP_EOL, $lines) . PHP_EOL);
+        $this->command->warn("Report written to: {$path}");
     }
 }

--- a/database/seeders/VehicleRoadTaxSeeder.php
+++ b/database/seeders/VehicleRoadTaxSeeder.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Branch;
+use App\Models\Scopes\BranchScope;
+use App\Models\Vehicle;
+use App\Models\VehicleService;
+use Carbon\Carbon;
+use DateTimeInterface;
+use Illuminate\Database\Seeder;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
+
+class VehicleRoadTaxSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $filePath = base_path('../VEHICLE LIST.xlsx');
+
+        if (!file_exists($filePath)) {
+            $this->command->error("Excel file not found at: {$filePath}");
+            return;
+        }
+
+        $rows = IOFactory::load($filePath)
+            ->getActiveSheet()
+            ->toArray(null, true, false, false);
+
+        $branchMap = [
+            'HQ'     => Branch::LOCATION_KL,
+            'PENANG' => Branch::LOCATION_PENANG,
+        ];
+
+        $seeded = 0;
+        $skippedNoExpiry = 0;
+        $skippedBranch = 0;
+        $skippedNoVehicle = 0;
+
+        foreach ($rows as $i => $row) {
+            if ($i === 0) continue;
+
+            $plate = trim($row[0] ?? '');
+            if ($plate === '') continue;
+
+            $expiryRaw = $row[9] ?? null;
+            if ($expiryRaw === null || (is_string($expiryRaw) && trim($expiryRaw) === '')) {
+                $skippedNoExpiry++;
+                continue;
+            }
+
+            $branchKey = strtoupper(trim($row[12] ?? ''));
+            if (!isset($branchMap[$branchKey])) {
+                $skippedBranch++;
+                continue;
+            }
+
+            $expiry = $expiryRaw;
+            if ($expiry instanceof DateTimeInterface) {
+                $expiry = $expiry->format('Y-m-d');
+            } elseif (is_numeric($expiry)) {
+                $expiry = ExcelDate::excelToDateTimeObject($expiry)->format('Y-m-d');
+            } else {
+                $expiry = trim((string) $expiry);
+            }
+
+            $vehicle = Vehicle::withoutGlobalScope(BranchScope::class)
+                ->where('plate_number', $plate)
+                ->first();
+
+            if ($vehicle === null) {
+                $skippedNoVehicle++;
+                continue;
+            }
+
+            $service = VehicleService::withoutGlobalScope(BranchScope::class)->updateOrCreate(
+                [
+                    'vehicle_id' => $vehicle->id,
+                    'type'       => 2,
+                ],
+                [
+                    'date'      => $expiry,
+                    'to_date'   => null,
+                    'remind_at' => Carbon::parse($expiry)->subMonths(1),
+                    'amount'    => null,
+                ]
+            );
+
+            $alreadyLinked = Branch::where('object_type', VehicleService::class)
+                ->where('object_id', $service->id)
+                ->exists();
+
+            if (!$alreadyLinked) {
+                Branch::create([
+                    'object_type' => VehicleService::class,
+                    'object_id'   => $service->id,
+                    'location'    => $branchMap[$branchKey],
+                ]);
+            }
+
+            $seeded++;
+        }
+
+        $this->command->info(
+            "Roadtax services seeded: {$seeded}, skipped (no expiry): {$skippedNoExpiry}, "
+            . "skipped (branch): {$skippedBranch}, skipped (no vehicle): {$skippedNoVehicle}."
+        );
+    }
+}

--- a/resources/views/production/form.blade.php
+++ b/resources/views/production/form.blade.php
@@ -1,5 +1,6 @@
 @inject('prodMs', 'App\Models\ProductionMilestone')
 @inject('prodMsMaterialPreview', 'App\Models\ProductionMilestoneMaterialPreview')
+@inject('prodModel', 'App\Models\Production')
 
 @extends('layouts.app')
 @section('title', 'Production')
@@ -198,7 +199,7 @@
                     <input type="hidden" name="material_use_product">
                 </div>
             </div>
-            @if (!isset($production) || (isset($production) && $production->type == 2) || (isset($is_duplicate) && $is_duplicate == true))
+            @if (!isset($production) || (isset($production) && $production->type == 2) || (isset($is_duplicate) && $is_duplicate == true) || (isset($production) && !isset($is_duplicate) && $production->status == $prodModel::STATUS_TO_DO))
                 <div class="mt-8 flex justify-end">
                     <x-app.button.submit type="button" id="submit-btn">{{ __('Save and Update') }}</x-app.button.submit>
                 </div>

--- a/tests/Feature/ProductionQuickDuplicateTest.php
+++ b/tests/Feature/ProductionQuickDuplicateTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature;
 
 use App\Models\Branch;
+use App\Models\Milestone;
 use App\Models\Production;
+use App\Models\ProductionMilestone;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Session;
@@ -102,5 +104,143 @@ class ProductionQuickDuplicateTest extends TestCase
         $newSkus = Production::where('id', '>', $beforeMaxId)->pluck('sku')->toArray();
         $this->assertCount(4, $newSkus);
         $this->assertCount(4, array_unique($newSkus), 'All four duplicated copies must have unique SKUs');
+    }
+
+    public function test_duplicate_has_status_to_do(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+
+        // Force source to a non-TO_DO status so the assertion is meaningful
+        $source->update(['status' => Production::STATUS_DOING]);
+
+        $beforeMaxId = (int) Production::max('id');
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+        $response->assertRedirect(route('production.index'));
+
+        $newProduction = Production::where('id', '>', $beforeMaxId)->first();
+        $this->assertNotNull($newProduction, 'Quick duplicate should have created a new production');
+        $this->assertSame(
+            Production::STATUS_TO_DO,
+            $newProduction->status,
+            'Duplicated production must start at STATUS_TO_DO regardless of source status'
+        );
+    }
+
+    public function test_duplicate_milestones_are_unchecked(): void
+    {
+        $user = User::first();
+        $this->actingAs($user);
+        $source = $this->aProduction();
+
+        $milestone = Milestone::first();
+        $this->assertNotNull($milestone, 'Expected at least one Milestone in the test DB');
+
+        // Ensure source has a milestone whose check-in state is populated,
+        // so the assertion catches any leak of submitted_at / submitted_by.
+        ProductionMilestone::updateOrCreate(
+            ['production_id' => $source->id, 'milestone_id' => $milestone->id],
+            ['sequence' => 1, 'submitted_at' => now(), 'submitted_by' => $user->id]
+        );
+
+        $beforeMaxId = (int) Production::max('id');
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+        $response->assertRedirect(route('production.index'));
+
+        $newProduction = Production::where('id', '>', $beforeMaxId)->first();
+        $this->assertNotNull($newProduction);
+
+        $newMilestones = ProductionMilestone::where('production_id', $newProduction->id)->get();
+        $this->assertGreaterThan(0, $newMilestones->count(), 'Duplicate should have at least one milestone');
+        foreach ($newMilestones as $pm) {
+            $this->assertNull($pm->submitted_at, 'Duplicated milestone must not be checked in');
+            $this->assertNull($pm->submitted_by, 'Duplicated milestone must not have a submitter');
+        }
+    }
+
+    public function test_duplicate_can_be_started_manually(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+
+        $beforeMaxId = (int) Production::max('id');
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+        $response->assertRedirect(route('production.index'));
+
+        $newProduction = Production::where('id', '>', $beforeMaxId)->first();
+        $this->assertNotNull($newProduction);
+        $this->assertSame(Production::STATUS_TO_DO, $newProduction->status);
+
+        $start = $this->get(route('production.to_in_progress').'?productionIds='.$newProduction->id);
+        $start->assertStatus(302);
+
+        $newProduction->refresh();
+        $this->assertSame(
+            Production::STATUS_DOING,
+            $newProduction->status,
+            'Duplicate should transition to STATUS_DOING after Start Task'
+        );
+        $this->assertNotNull(
+            $newProduction->product_child_id,
+            'Start Task should attach a product_child to the duplicate'
+        );
+    }
+
+    public function test_duplicate_progress_is_zero_percent(): void
+    {
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+
+        $beforeMaxId = (int) Production::max('id');
+        $response = $this->get(route('production.quick_duplicate', $source->id));
+        $response->assertRedirect(route('production.index'));
+
+        $newProduction = Production::where('id', '>', $beforeMaxId)->first();
+        $this->assertNotNull($newProduction);
+
+        // Progress is 0 whether the duplicate copied milestones (none submitted)
+        // or has zero milestones at all.
+        $this->assertSame(
+            0,
+            (int) $newProduction->getProgress($newProduction),
+            'Freshly duplicated production must show 0% progress'
+        );
+    }
+
+    public function test_progress_is_zero_when_production_has_no_milestones(): void
+    {
+        // Use an in-memory Production with an id that has no milestone rows.
+        // Avoids touching real records (per CLAUDE.md "don't delete records").
+        $unsavedId = ((int) Production::max('id')) + 100000;
+        $p = new Production();
+        $p->id = $unsavedId;
+
+        $this->assertSame(
+            0,
+            (int) $p->getProgress($p),
+            'Production with zero milestones must report 0% progress, not 100%'
+        );
+    }
+
+    public function test_edit_form_shows_update_button_for_to_do_production(): void
+    {
+        Permission::firstOrCreate(['name' => 'production.edit', 'guard_name' => 'web']);
+        Permission::firstOrCreate(['name' => 'production.view', 'guard_name' => 'web']);
+
+        $this->actingAs(User::first());
+        $source = $this->aProduction();
+
+        // Quick-duplicate to get a TO_DO Normal-type production
+        $beforeMaxId = (int) Production::max('id');
+        $this->get(route('production.quick_duplicate', $source->id))
+            ->assertRedirect(route('production.index'));
+
+        $duplicate = Production::where('id', '>', $beforeMaxId)->first();
+        $this->assertNotNull($duplicate);
+        $this->assertSame(Production::STATUS_TO_DO, $duplicate->status);
+
+        $response = $this->get(route('production.edit', $duplicate->id));
+        $response->assertStatus(200);
+        $response->assertSee('id="submit-btn"', false);
     }
 }


### PR DESCRIPTION
…ride service, and production fixes

- Add app:import-raw-materials command to hard-delete and re-import raw material / spare part products from an Excel spreadsheet with dry-run and force options
- Add app:renumber-products command to contiguously renumber products.id and attachments.id, propagating changes across all FK and morph tables
- Add app:update-product-classification-code command to bulk-sync the classification code pivot for all live products
- Add app:update-product-uom command to realign products.uom from master FG and RM/SP spreadsheets, auto-creating missing UOM rows for type-2
- Add ProductMergeService with SKU normalization helpers used by the photo seeder (filename char-substitution and candidate list generation)
- Add SparePartPhotoOverrides service with a hardcoded + file-driven (sp-rm-feedback.txt) filename-to-SKU override map
- Refactor SparePartPhotoSeeder to use overrides and normalizer candidates, target SPARE PART PHOTOS 6, support multi-subfolder FG photos, and emit a merged unmatched/no-photo report file
- Add VehicleRoadTaxSeeder to upsert road-tax VehicleService records from VEHICLE LIST.xlsx and register it in DatabaseSeeder
- Fix quick-duplicate to clear submitted_at/submitted_by on cloned milestones so duplicates always start unchecked
- Fix Production::getProgress to return 0% (not 100%) when a production has zero milestones
- Fix rejectMilestone to compare status against Production::STATUS_DOING constant instead of a raw string
- Show "Save and Update" button on the production edit form for TO_DO Normal-type productions
- Expand ProductionQuickDuplicateTest with 6 new cases covering status reset, milestone unchecked state, manual start, progress calculation, zero-milestone progress, and form button visibility