### PR TITLE
fix(sale,pdf): correct FOC accessory display and warranty period dele…

### DIFF
--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -3004,7 +3004,6 @@ class SaleController extends Controller
                                 'discount_type' => $req->discount_type[$i] ?? 'fixed',
                                 'remark' => $req->product_remark[$i],
                             ]);
-                            SaleProductWarrantyPeriod::where('sale_product_id', $sp->id)->delete();
                         }
                     } else {
                         $sp = SaleProduct::create([
@@ -3027,6 +3026,7 @@ class SaleController extends Controller
                             'sequence' => $req->sequence[$i] ?? null,
                         ]);
                     }
+                    SaleProductWarrantyPeriod::where('sale_product_id', $sp->id)->forceDelete();
                     // Warranty Period
                     if (is_array($req->warranty_period) && isset($req->warranty_period[$i]) && is_array($req->warranty_period[$i])) {
                         $spwp_data = [];

--- a/resources/views/quotation/hi_ten_pdf.blade.php
+++ b/resources/views/quotation/hi_ten_pdf.blade.php
@@ -267,11 +267,11 @@
                             <td colspan="2"></td>
                             <td style="font-size: 10px; text-align: left;">- {{ $accessory->product->model_desc ?? 'N/A' }}</td>
                             <td style="font-size: 10px; text-align: right;">{{ $acc_qty }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : ($accessory->product->uomUnit->name ?? '') }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ number_format($unit_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->product->uomUnit->name ?? '' }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : number_format($unit_price, 2) }}</td>
                             <td style="font-size: 10px; text-align: right;">{{ number_format(0, 2) }}</td>
                             <td style="font-size: 10px; text-align: right;">{{ number_format(0, 2) }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ number_format($total_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : number_format($total_price, 2) }}</td>
                         </tr>
                     @endforeach
                 @endif

--- a/resources/views/quotation/powercool_pdf.blade.php
+++ b/resources/views/quotation/powercool_pdf.blade.php
@@ -285,10 +285,10 @@
                             <td colspan="3"></td>
                             <td style="font-size: 10px; text-align: left;">- {{ $accessory->product->model_desc ?? 'N/A' }}</td>
                             <td style="font-size: 10px; text-align: right;">{{ $acc_qty }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : ($accessory->product->uomUnit->name ?? '') }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ number_format($unit_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->product->uomUnit->name ?? '' }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : number_format($unit_price, 2) }}</td>
                             <td style="font-size: 10px; text-align: right;">{{ number_format(0, 2) }}</td>
-                            <td style="font-size: 10px; text-align: right;">{{ number_format($total_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right;">{{ $accessory->is_foc ? 'FOC' : number_format($total_price, 2) }}</td>
                         </tr>
                     @endforeach
                 @endif

--- a/resources/views/sale_order/hi_ten_pdf.blade.php
+++ b/resources/views/sale_order/hi_ten_pdf.blade.php
@@ -258,11 +258,11 @@
                             <td style="font-size: 10px; text-align: left;">- {{ $accessory->product->model_desc ?? 'N/A' }}</td>
                             <td style="font-size: 10px; text-align: right; width: 4%;">{{ $acc_qty }}</td>
                             <td style="font-size: 10px; text-align: right; width: 4%;"></td>
-                            <td style="font-size: 10px; text-align: right; width: 4%;">{{ $accessory->is_foc ? 'FOC' : ($accessory->product->uomUnit->name ?? '') }}</td>
-                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format($unit_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 4%;">{{ $accessory->product->uomUnit->name ?? '' }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ $accessory->is_foc ? 'FOC' : number_format($unit_price, 2) }}</td>
                             <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format(0, 2) }}</td>
                             <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format(0, 2) }}</td>
-                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format($total_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ $accessory->is_foc ? 'FOC' : number_format($total_price, 2) }}</td>
                         </tr>
                     @endforeach
                 @endif

--- a/resources/views/sale_order/powercool_pdf.blade.php
+++ b/resources/views/sale_order/powercool_pdf.blade.php
@@ -278,11 +278,11 @@
                             <td style="width: 12%;"></td>
                             <td style="font-size: 10px; text-align: left;">- {{ $accessory->product->model_desc ?? 'N/A' }}</td>
                             <td style="font-size: 10px; text-align: right; width: 4%;">{{ $acc_qty }}</td>
-                            <td style="font-size: 10px; text-align: right; width: 4%;">{{ $accessory->is_foc ? 'FOC' : ($accessory->product->uomUnit->name ?? '') }}</td>
-                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format($unit_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 4%;">{{ $accessory->product->uomUnit->name ?? '' }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ $accessory->is_foc ? 'FOC' : number_format($unit_price, 2) }}</td>
                             <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format(0, 2) }}</td>
                             <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format(0, 2) }}</td>
-                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ number_format($total_price, 2) }}</td>
+                            <td style="font-size: 10px; text-align: right; width: 9%;">{{ $accessory->is_foc ? 'FOC' : number_format($total_price, 2) }}</td>
                         </tr>
                     @endforeach
                 @endif


### PR DESCRIPTION
…tion

- PDF templates (quotation + sale order, both brands): fix FOC accessory rows so the UOM unit name is always displayed and "FOC" replaces the unit price and total price columns instead of the UOM column
- SaleController: move SaleProductWarrantyPeriod cleanup outside the update-only branch so it applies to both create and update paths, and switch to forceDelete() to remove soft-deleted warranty period records