### PR TITLE
feat(quotation,sale): auto-fill report type from debtor type and make…

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -726,9 +726,13 @@ class CustomerController extends Controller
                 $locations = CustomerLocation::where('customer_id', $req->customer_id)->get();
             }
 
+            $customer = Customer::with('debtorType')->find($req->customer_id);
+            $debtor_type_name = $customer && $customer->debtorType ? $customer->debtorType->name : null;
+
             return Response::json([
                 'result' => true,
                 'locations' => $locations,
+                'debtor_type_name' => $debtor_type_name,
             ], HttpFoundationResponse::HTTP_OK);
         } catch (\Throwable $th) {
             DB::rollBack();
@@ -822,11 +826,11 @@ class CustomerController extends Controller
             $is_edit = $req->boolean('is_edit');
 
             if ($is_edit) {
-                $customers = Customer::with('creditTerms.creditTerm', 'salesAgents')
+                $customers = Customer::with('creditTerms.creditTerm', 'salesAgents', 'debtorType')
                     ->where('company_name', 'like', '%' . $keyword . '%')
                     ->orderBy('id', 'desc')->get();
             } else {
-                $customers = Customer::with('creditTerms.creditTerm', 'salesAgents')
+                $customers = Customer::with('creditTerms.creditTerm', 'salesAgents', 'debtorType')
                     ->where('company_name', 'like', '%' . $keyword . '%')
                     ->whereIn('status', [Customer::STATUS_ACTIVE, Customer::STATUS_APPROVAL_APPROVED])
                     ->orderBy('id', 'desc')

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -307,7 +307,7 @@ class SaleController extends Controller
             $replicate = Sale::where('id', $req->quo)->first();
             $data['replicate'] = $replicate->load('products.product.children', 'products.children', 'products.warrantyPeriods', 'products.accessories.product', 'products.accessories.sellingPrice');
 
-            $customers = Customer::with('creditTerms.creditTerm', 'salesAgents')
+            $customers = Customer::with('creditTerms.creditTerm', 'salesAgents', 'debtorType')
                 ->where('id', $replicate->customer_id)
                 ->orderBy('id', 'desc')->get();
             $customers = $customers->keyBy('id')->all();
@@ -343,7 +343,7 @@ class SaleController extends Controller
             abort(403);
         }
 
-        $customers = Customer::with('creditTerms.creditTerm', 'salesAgents')
+        $customers = Customer::with('creditTerms.creditTerm', 'salesAgents', 'debtorType')
             ->where('id', $sale->customer_id)
             ->orderBy('id', 'desc')->get();
         $customers = $customers->keyBy('id')->all();
@@ -590,10 +590,12 @@ class SaleController extends Controller
     {
         $rules = [
             'payment_method' => 'required',
-            'payment_due_date' => 'required',
         ];
         if (in_array($req->payment_method, getPaymentMethodCreditTermIds())) {
             $rules['payment_term'] = 'required';
+        }
+        if (! in_array($req->payment_method, getPaymentMethodOptionalDueDateIds())) {
+            $rules['payment_due_date'] = 'required';
         }
         $req->validate($rules);
 
@@ -1175,7 +1177,7 @@ class SaleController extends Controller
 
         $has_pending_approval = Approval::where('object_type', Sale::class)->where('object_id', $sale->id)->where('status', Approval::STATUS_PENDING_APPROVAL)->exists();
 
-        $customers = Customer::with('creditTerms.creditTerm', 'salesAgents')
+        $customers = Customer::with('creditTerms.creditTerm', 'salesAgents', 'debtorType')
             ->where('id', $sale->customer_id)
             ->orderBy('id', 'desc')->get();
         $customers = $customers->keyBy('id')->all();
@@ -2046,10 +2048,12 @@ class SaleController extends Controller
             }
 
             // Update payment due date for SOs if payment method is credit term and payment due date is null
-            $credit_term_payment_term_ids = getPaymentMethodCreditTermIds();
+            $credit_term_payment_method_ids = getPaymentMethodCreditTermIds();
             for ($i = 0; $i < count($sales); $i++) {
-                if (in_array($sales[$i]->payment_term, $credit_term_payment_term_ids) && $sales[$i]->payment_due_date == null) {
-                    $daysToAdd = str_replace(' Days', '', $sales[$i]->paymentTerm->name);
+                if (in_array($sales[$i]->payment_method, $credit_term_payment_method_ids)
+                    && $sales[$i]->payment_due_date == null
+                    && $sales[$i]->paymentTerm != null) {
+                    $daysToAdd = (int) str_replace(' Days', '', $sales[$i]->paymentTerm->name);
                     $sales[$i]->payment_due_date = now()->addDays($daysToAdd)->format('Y-m-d');
                     $sales[$i]->save();
                 }

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -730,12 +730,14 @@ class ViewServiceProvider extends ServiceProvider
             $payment_methods = PaymentMethod::orderBy('name', 'asc')->get();
             $credit_terms = CreditTerm::orderBy('id', 'desc')->get();
             $credit_term_payment_method_ids = getPaymentMethodCreditTermIds();
+            $optional_due_date_payment_method_ids = getPaymentMethodOptionalDueDateIds();
 
             $view->with([
                 'can_payment_amount' => hasPermission('sale.sale_order.payment'),
                 'payment_statuses' => $payment_statuses,
                 'payment_methods' => $payment_methods,
                 'credit_payment_method_ids' => $credit_term_payment_method_ids,
+                'optional_due_date_payment_method_ids' => $optional_due_date_payment_method_ids,
                 'credit_terms' => $credit_terms,
             ]);
         });

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -498,3 +498,12 @@ if (! function_exists('getPaymentMethodCreditTermIds')) {
         return PaymentMethod::where('name', 'like', '%credit term%')->pluck('id')->toArray();
     }
 }
+
+if (! function_exists('getPaymentMethodOptionalDueDateIds')) {
+    function getPaymentMethodOptionalDueDateIds()
+    {
+        return PaymentMethod::where('name', 'like', '%credit term%')
+            ->orWhere('name', 'like', '%installment%')
+            ->pluck('id')->toArray();
+    }
+}

--- a/resources/views/quotation/convert.blade.php
+++ b/resources/views/quotation/convert.blade.php
@@ -233,7 +233,7 @@
                                 <x-app.message.error id="payment_term_err" />
                             </div>
                             <div class="flex flex-col">
-                                <x-app.input.label id="payment_due_date" class="mb-1">{{ __('Payment Due Date') }} <span class="text-sm text-red-500">*</span></x-app.input.label>
+                                <x-app.input.label id="payment_due_date" class="mb-1">{{ __('Payment Due Date') }} <span class="text-sm text-red-500" id="payment_due_date_required">*</span></x-app.input.label>
                                 <x-app.input.input name="payment_due_date" id="payment_due_date" :hasError="false" />
                                 <x-app.message.error id="payment_due_date_err" />
                             </div>
@@ -273,6 +273,7 @@
         SALESPERSONS = @json($salespersons ?? null);
         QUOTATIONS = @json($quotations ?? null);
         CREDIT_PAYMENT_METHOD_IDS = @json($credit_payment_method_ids ?? []);
+        OPTIONAL_DUE_DATE_PAYMENT_METHOD_IDS = @json($optional_due_date_payment_method_ids ?? []);
         SELECTED_QUOS = [];
         CURRENT_SUBSTEP = 3;
 
@@ -419,6 +420,11 @@
                 $('#convert-payment-term-container').addClass('hidden')
                 $('select[name="payment_term"]').val('').trigger('change')
             }
+            if (OPTIONAL_DUE_DATE_PAYMENT_METHOD_IDS.includes(parseInt(val))) {
+                $('#payment_due_date_required').addClass('hidden')
+            } else {
+                $('#payment_due_date_required').removeClass('hidden')
+            }
             if (CURRENT_SUBSTEP == 4) updateStep4Url()
         })
         $('select[name="payment_term"]').on('change', function() {
@@ -460,11 +466,13 @@
                 }
             }
 
-            let paymentDueDate = $('input[name="payment_due_date"]').val()
-            if (!paymentDueDate || paymentDueDate == '') {
-                errors.push('Payment due date is required')
-                $('#payment_due_date_err').find('p').text('Payment due date is required')
-                $('#payment_due_date_err').removeClass('hidden')
+            if (!OPTIONAL_DUE_DATE_PAYMENT_METHOD_IDS.includes(parseInt(paymentMethod))) {
+                let paymentDueDate = $('input[name="payment_due_date"]').val()
+                if (!paymentDueDate || paymentDueDate == '') {
+                    errors.push('Payment due date is required')
+                    $('#payment_due_date_err').find('p').text('Payment due date is required')
+                    $('#payment_due_date_err').removeClass('hidden')
+                }
             }
 
             if (errors.length > 0) {

--- a/resources/views/quotation/form_step/quotation_details.blade.php
+++ b/resources/views/quotation/form_step/quotation_details.blade.php
@@ -356,6 +356,32 @@
 
             $('select[name="sale"]').val(null).trigger('change')
 
+            // Auto-select Type from customer's debtor type
+            if (customer_id) {
+                let skipTypeAutoFill = (typeof SALE !== 'undefined' && SALE != null && QUOTATION_DETAILS_INIT_EDIT == true)
+                if (!skipTypeAutoFill) {
+                    $.ajax({
+                        url: '{{ route('customer.get_location') }}',
+                        type: 'GET',
+                        data: { customer_id: customer_id },
+                        headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
+                        success: function(r) {
+                            if (!r.debtor_type_name) return
+                            let typeName = r.debtor_type_name.toString().trim().toLowerCase()
+                            let $select = $('select[name="report_type"]')
+                            $select.find('option').each(function() {
+                                if ($(this).val() && $(this).text().toString().trim().toLowerCase() === typeName) {
+                                    $select.find('option').prop('selected', false)
+                                    $(this).prop('selected', true)
+                                    $select.val($(this).val()).trigger('change')
+                                    return false
+                                }
+                            })
+                        }
+                    })
+                }
+            }
+
             var element = CUSTOMERS[customer_id]
             $('input[name="attention_to"]').val(element.name)
             // Show the first mobile number or '-' if not available

--- a/resources/views/sale_order/form_step/quotation_details.blade.php
+++ b/resources/views/sale_order/form_step/quotation_details.blade.php
@@ -262,6 +262,33 @@
 
         $('select[name="customer"]').on('change', function() {
             var customer_id = $(this).val()
+
+            // Auto-select Type from customer's debtor type
+            if (customer_id) {
+                let skipTypeAutoFill = (typeof SALE !== 'undefined' && SALE != null && INIT_EDIT == true)
+                if (!skipTypeAutoFill) {
+                    $.ajax({
+                        url: '{{ route('customer.get_location') }}',
+                        type: 'GET',
+                        data: { customer_id: customer_id },
+                        headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
+                        success: function(r) {
+                            if (!r.debtor_type_name) return
+                            let typeName = r.debtor_type_name.toString().trim().toLowerCase()
+                            let $select = $('select[name="report_type"]')
+                            $select.find('option').each(function() {
+                                if ($(this).val() && $(this).text().toString().trim().toLowerCase() === typeName) {
+                                    $select.find('option').prop('selected', false)
+                                    $(this).prop('selected', true)
+                                    $select.val($(this).val()).trigger('change')
+                                    return false
+                                }
+                            })
+                        }
+                    })
+                }
+            }
+
             var element = CUSTOMERS[customer_id]
             $('input[name="attention_to"]').val(element.name)
             // Show the first mobile number or '-' if not available
@@ -295,6 +322,7 @@
                 type: 'GET',
                 async: false,
                 success: function(res) {
+
                     $('select[name="billing_address"] option').remove()
 
                     // Default option
@@ -401,6 +429,32 @@
             $('input[name="customer_label"]').val(customer_label)
             $('input[name="customer"]').val(customer_id)
 
+            // Auto-select Type from customer's debtor type
+            if (customer_id) {
+                let skipTypeAutoFill = (typeof SALE !== 'undefined' && SALE != null && INIT_EDIT == true)
+                if (!skipTypeAutoFill) {
+                    $.ajax({
+                        url: '{{ route('customer.get_location') }}',
+                        type: 'GET',
+                        data: { customer_id: customer_id },
+                        headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
+                        success: function(r) {
+                            if (!r.debtor_type_name) return
+                            let typeName = r.debtor_type_name.toString().trim().toLowerCase()
+                            let $select = $('select[name="report_type"]')
+                            $select.find('option').each(function() {
+                                if ($(this).val() && $(this).text().toString().trim().toLowerCase() === typeName) {
+                                    $select.find('option').prop('selected', false)
+                                    $(this).prop('selected', true)
+                                    $select.val($(this).val()).trigger('change')
+                                    return false
+                                }
+                            })
+                        }
+                    })
+                }
+            }
+
             var element = CUSTOMERS[customer_id]
 
             $('input[name="attention_to"]').val(element.name)
@@ -423,6 +477,7 @@
                 type: 'GET',
                 async: false,
                 success: function(res) {
+
                     // Billing Address
                     $('select[name="billing_address"] option').remove()
 


### PR DESCRIPTION
… payment due date conditional

- CustomerController: include debtorType relation in getLocation and getByKeyword responses
- SaleController: eager-load debtorType on customer queries in create, edit, editSaleOrder; make payment_due_date validation conditional via getPaymentMethodOptionalDueDateIds; fix converToDeliveryOrder to check payment_method (not payment_term) when auto-computing payment due date, guard against null paymentTerm, and cast days to int
- helpers.php: add getPaymentMethodOptionalDueDateIds() for credit term and installment methods
- ViewServiceProvider: expose optional_due_date_payment_method_ids to convert view
- quotation/convert.blade.php: hide/show required asterisk and skip validation for payment due date when payment method is credit term or installment
- quotation/form_step/quotation_details.blade.php: auto-select report_type on customer change using debtor_type_name from getLocation, skip on edit mode
- sale_order/form_step/quotation_details.blade.php: same auto-select logic on customer change and hintClickedCallback, skip on edit mode