### PR TITLE
feat(product,inventory,quotation,sale): add display qty and UOM field…

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -799,6 +799,9 @@ class ProductController extends Controller
 
             'classification_code' => 'required|array',
             'classification_code.*' => 'exists:classification_codes,id',
+
+            'display_qty' => 'nullable|numeric|min:0',
+            'display_uom' => 'nullable|exists:uom,id',
         ];
         if ($req->product_id != null) {
             $rules['image'] = 'nullable';
@@ -891,6 +894,8 @@ class ProductController extends Controller
                     'woo_commerce_sku' => $req->woo_commerce_sku,
                     'hi_ten_stock_code' => $req->hi_ten_stock_code,
                     'sst' => $req->sst == null ? false : true,
+                    'display_qty' => $req->display_qty,
+                    'display_uom' => $req->display_uom,
                     'created_by' => Auth::user()->id,
                 ]);
 
@@ -931,6 +936,8 @@ class ProductController extends Controller
                     'woo_commerce_sku' => $req->woo_commerce_sku,
                     'hi_ten_stock_code' => $req->hi_ten_stock_code,
                     'sst' => $req->sst == null ? false : true,
+                    'display_qty' => $req->display_qty,
+                    'display_uom' => $req->display_uom,
                 ]);
             }
 
@@ -1283,6 +1290,7 @@ class ProductController extends Controller
                 $q->whereNull('status')->whereNotIn('id', $involved_pc_ids);
             }])
                 ->with('sellingPrices')
+                ->with('displayUomUnit')
                 ->where('is_active', true)
                 ->where(function ($q) use ($keyword) {
                     $q->where('model_desc', 'like', '%'.$keyword.'%')

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -57,6 +57,11 @@ class Product extends Model
         return $this->belongsTo(UOM::class, 'uom');
     }
 
+    public function displayUomUnit()
+    {
+        return $this->belongsTo(UOM::class, 'display_uom');
+    }
+
     public function branch()
     {
         return $this->morphOne(Branch::class, 'object');

--- a/database/migrations/2026_05_11_100000_add_display_qty_and_display_uom_on_products_table.php
+++ b/database/migrations/2026_05_11_100000_add_display_qty_and_display_uom_on_products_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('display_qty', 12, 2)->nullable()->after('uom');
+            $table->string('display_uom')->nullable()->after('display_qty');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['display_qty', 'display_uom']);
+        });
+    }
+};

--- a/resources/views/inventory/form.blade.php
+++ b/resources/views/inventory/form.blade.php
@@ -125,6 +125,22 @@
                             value="{{ old('qty', isset($prod) ? $prod->qty : ($dup_prod != null ? $dup_prod->qty : null)) }}" />
                         <x-input-error :messages="$errors->get('qty')" class="mt-1" />
                     </div>
+                    <div class="flex flex-col" id="display-qty-container">
+                        <x-app.input.label id="display_qty" class="mb-1">{{ __('Display Qty') }}</x-app.input.label>
+                        <x-app.input.input name="display_qty" id="display_qty" class="decimal-input"
+                            value="{{ old('display_qty', isset($prod) ? $prod->display_qty : ($dup_prod != null ? $dup_prod->display_qty : null)) }}" />
+                        <x-input-error :messages="$errors->get('display_qty')" class="mt-1" />
+                    </div>
+                    <div class="flex flex-col" id="display-uom-container">
+                        <x-app.input.label id="display_uom" class="mb-1">{{ __('Display UOM') }}</x-app.input.label>
+                        <x-app.input.select name="display_uom" id="display_uom">
+                            <option value="">{{ __('Select a UOM') }}</option>
+                            @foreach ($uoms as $uom)
+                                <option value="{{ $uom->id }}" @selected(old('display_uom', isset($prod) ? $prod->display_uom : ($dup_prod != null ? $dup_prod->display_uom : null)) == $uom->id)>{{ $uom->name }}</option>
+                            @endforeach
+                        </x-app.input.select>
+                        <x-input-error :messages="$errors->get('display_uom')" class="mt-1" />
+                    </div>
                 @endif
                 <div class="flex flex-col">
                     <x-app.input.label id="low_stock_threshold"

--- a/resources/views/quotation/form_step/product_details.blade.php
+++ b/resources/views/quotation/form_step/product_details.blade.php
@@ -68,8 +68,21 @@
             <x-app.message.error id="customize_product_err" />
         </div>
         <div class="flex flex-col">
-            <x-app.input.label id="qty" class="mb-1">{{ __('Quantity') }} <span
-                    class="text-sm text-red-500">*</span></x-app.input.label>
+            <x-app.input.label id="qty" class="mb-1 flex items-center gap-1">
+                {{ __('Quantity') }} <span class="text-sm text-red-500">*</span>
+                <span class="display-info-wrapper relative hidden">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                        class="display-info-icon h-4 w-4 text-blue-500 hover:text-blue-700 cursor-pointer"
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <div class="display-info-tooltip hidden absolute left-6 top-0 z-50 w-56 bg-white rounded-lg shadow-lg border border-gray-200 p-3 text-xs font-normal text-gray-700">
+                        <div><span class="font-semibold">{{ __('Display Qty') }}:</span> <span class="display-qty-value">-</span></div>
+                        <div class="mt-1"><span class="font-semibold">{{ __('Display UOM') }}:</span> <span class="display-uom-value">-</span></div>
+                    </div>
+                </span>
+            </x-app.input.label>
             <div class="flex border border-gray-300 rounded-md overflow-hidden">
                 <x-app.input.input name="qty" id="qty" :hasError="$errors->has('qty')"
                     class="int-input border-none flex-1" />
@@ -516,6 +529,12 @@
             hideDeleteBtnWhenOnlyOneItem()
             calSummary()
         })
+        $('body').on('mouseenter', '.display-info-wrapper', function() {
+            $(this).find('.display-info-tooltip').removeClass('hidden')
+        })
+        $('body').on('mouseleave', '.display-info-wrapper', function() {
+            $(this).find('.display-info-tooltip').addClass('hidden')
+        })
         $('body').on('change', 'select[name="selling_price[]"]', function() {
             let idx = $(this).parent().parent().data('id')
             let productId = $(`.items[data-id="${idx}"] select[name="product_id[]"]`).val()
@@ -581,6 +600,19 @@
                     }
                 }
                 $(`.items[data-id="${id}"] input[name="product_desc"]`).val(product.model_desc)
+
+                // Display qty/uom tooltip (RM only)
+                let $displayWrap = $(`.items[data-id="${id}"] .display-info-wrapper`)
+                let isRM = product.type == 2
+                let displayUomName = product.display_uom_unit ? product.display_uom_unit.name : null
+                if (isRM && (product.display_qty != null || displayUomName != null)) {
+                    $(`.items[data-id="${id}"] .display-qty-value`).text(product.display_qty != null ? product.display_qty : '-')
+                    $(`.items[data-id="${id}"] .display-uom-value`).text(displayUomName != null ? displayUomName : '-')
+                    $displayWrap.removeClass('hidden')
+                } else {
+                    $displayWrap.addClass('hidden')
+                }
+
                 // Append selling prices
                 $(`.items[data-id="${id}"] select[name="selling_price[]"]`).empty()
                 $(`.items[data-id="${id}"] select[name="selling_price[]"]`).append('<option value="">{{ __('Select price') }}</option>')

--- a/resources/views/sale_order/form_step/product_details.blade.php
+++ b/resources/views/sale_order/form_step/product_details.blade.php
@@ -95,8 +95,21 @@
             <x-app.message.error id="customize_product_err" />
         </div>
         <div class="flex flex-col">
-            <x-app.input.label id="qty" class="mb-1">{{ __('Quantity') }} <span
-                    class="text-sm text-red-500">*</span></x-app.input.label>
+            <x-app.input.label id="qty" class="mb-1 flex items-center gap-1">
+                {{ __('Quantity') }} <span class="text-sm text-red-500">*</span>
+                <span class="display-info-wrapper relative hidden">
+                    <svg xmlns="http://www.w3.org/2000/svg"
+                        class="display-info-icon h-4 w-4 text-blue-500 hover:text-blue-700 cursor-pointer"
+                        fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <div class="display-info-tooltip hidden absolute left-6 top-0 z-50 w-56 bg-white rounded-lg shadow-lg border border-gray-200 p-3 text-xs font-normal text-gray-700">
+                        <div><span class="font-semibold">{{ __('Display Qty') }}:</span> <span class="display-qty-value">-</span></div>
+                        <div class="mt-1"><span class="font-semibold">{{ __('Display UOM') }}:</span> <span class="display-uom-value">-</span></div>
+                    </div>
+                </span>
+            </x-app.input.label>
             <div class="flex border border-gray-300 rounded-md overflow-hidden">
                 <x-app.input.input name="qty" id="qty" :hasError="$errors->has('qty')"
                     class="int-input border-none flex-1" />
@@ -564,6 +577,12 @@
             hideDeleteBtnWhenOnlyOneItem()
             calSummary()
         })
+        $('body').on('mouseenter', '.display-info-wrapper', function() {
+            $(this).find('.display-info-tooltip').removeClass('hidden')
+        })
+        $('body').on('mouseleave', '.display-info-wrapper', function() {
+            $(this).find('.display-info-tooltip').addClass('hidden')
+        })
         $('body').on('change', 'select[name="selling_price[]"]', function() {
             let idx = $(this).parent().parent().data('id')
             let productId = $(`.items[data-id="${idx}"] select[name="product_id[]"]`).val()
@@ -632,6 +651,19 @@
                         }
                     }
                     $(`.items[data-id="${id}"] input[name="product_desc"]`).val(prod.model_desc)
+
+                    // Display qty/uom tooltip (RM only)
+                    let $displayWrap = $(`.items[data-id="${id}"] .display-info-wrapper`)
+                    let isRM = prod.type == 2
+                    let displayUomName = prod.display_uom_unit ? prod.display_uom_unit.name : null
+                    if (isRM && (prod.display_qty != null || displayUomName != null)) {
+                        $(`.items[data-id="${id}"] .display-qty-value`).text(prod.display_qty != null ? prod.display_qty : '-')
+                        $(`.items[data-id="${id}"] .display-uom-value`).text(displayUomName != null ? displayUomName : '-')
+                        $displayWrap.removeClass('hidden')
+                    } else {
+                        $displayWrap.addClass('hidden')
+                    }
+
                     // Append selling prices
                     $(`.items[data-id="${id}"] select[name="selling_price[]"]`).empty()
                     $(`.items[data-id="${id}"] select[name="selling_price[]"]`).append('<option value="">{{ __('Select price') }}</option>')

--- a/tests/Feature/ProductDisplayQtyUomTest.php
+++ b/tests/Feature/ProductDisplayQtyUomTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InventoryCategory;
+use App\Models\Product;
+use App\Models\UOM;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ProductDisplayQtyUomTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private function makeRawMaterial(array $overrides = []): Product
+    {
+        return Product::create(array_merge([
+            'inventory_category_id' => InventoryCategory::first()->id,
+            'type' => Product::TYPE_RAW_MATERIAL,
+            'sku' => 'TEST-DISP-'.uniqid(),
+            'model_desc' => 'Display Qty/UOM Test',
+            'is_sparepart' => false,
+            'is_active' => true,
+        ], $overrides));
+    }
+
+    public function test_display_qty_and_display_uom_persist_on_raw_material(): void
+    {
+        $uom = UOM::first();
+        $this->assertNotNull($uom, 'Seeded UOM required for this test');
+
+        $prod = $this->makeRawMaterial([
+            'display_qty' => 24.5,
+            'display_uom' => $uom->id,
+        ]);
+
+        $prod->refresh();
+
+        $this->assertEquals(24.5, (float) $prod->display_qty);
+        $this->assertEquals($uom->id, (int) $prod->display_uom);
+    }
+
+    public function test_display_uom_unit_relationship_resolves(): void
+    {
+        $uom = UOM::first();
+        $this->assertNotNull($uom);
+
+        $prod = $this->makeRawMaterial([
+            'display_qty' => 12,
+            'display_uom' => $uom->id,
+        ]);
+
+        $this->assertInstanceOf(UOM::class, $prod->displayUomUnit);
+        $this->assertSame($uom->id, $prod->displayUomUnit->id);
+    }
+
+    public function test_display_fields_nullable(): void
+    {
+        $prod = $this->makeRawMaterial();
+
+        $prod->refresh();
+
+        $this->assertNull($prod->display_qty);
+        $this->assertNull($prod->display_uom);
+        $this->assertNull($prod->displayUomUnit);
+    }
+
+    public function test_display_uom_unit_serializes_as_nested_relation(): void
+    {
+        $uom = UOM::first();
+        $this->assertNotNull($uom);
+
+        $prod = $this->makeRawMaterial([
+            'display_qty' => 6,
+            'display_uom' => $uom->id,
+        ]);
+
+        $arr = Product::with('displayUomUnit')->find($prod->id)->toArray();
+
+        $this->assertArrayHasKey('display_uom_unit', $arr);
+        $this->assertSame($uom->name, $arr['display_uom_unit']['name']);
+        $this->assertSame('6.00', (string) $arr['display_qty']);
+    }
+}


### PR DESCRIPTION
…s for raw materials

- Add migration: display_qty (decimal 12,2) and display_uom (FK to uom) columns on products table
- Add displayUomUnit() belongsTo relationship on Product model
- Validate and persist display_qty / display_uom in ProductController upsert (create & update paths)
- Eager-load displayUomUnit in getByKeyword so quotation/sale AJAX receives the relation
- Add Display Qty and Display UOM inputs to the inventory form (shown alongside existing qty/uom)
- Show a hoverable info icon tooltip next to the Quantity label in quotation and sale order product detail forms; tooltip reveals display_qty and display_uom name for RM-type products only
- Add feature test (ProductDisplayQtyUomTest) covering: persistence, relationship resolution, nullable defaults, and JSON serialization of the nested relation